### PR TITLE
PATCH: refactoring useAsyncErrorBoundaryQuery hook

### DIFF
--- a/src/common/useAsyncErrorBoundaryQuery.tsx
+++ b/src/common/useAsyncErrorBoundaryQuery.tsx
@@ -8,23 +8,77 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import AsyncErrorBoundary from "./AsyncErrorBoundary";
 
-/**
- * A custom hook with the same effect as setting 'suspense' option of 'useQuery' to 'true'.
- * Primarily used with {@link AsyncErrorBoundary}.
- */
-export const useAsyncErrorBoundaryQuery = <
+export interface BaseUseAsyncErrorBoundaryResult<TData = unknown>
+  extends Omit<UseQueryResult<TData>, "error" | "isError" | "isFetching"> {
+  status: "success" | "loading";
+}
+
+export interface UseAsyncErrorBoundaryResultOnSuccess<TData>
+  extends BaseUseAsyncErrorBoundaryResult<TData> {
+  isLoading: false;
+  isSuccess: true;
+  status: "success";
+  data: TData;
+}
+
+export interface UseAsyncErrorBoundaryResultOnLoading
+  extends BaseUseAsyncErrorBoundaryResult {
+  isLoading: true;
+  isSuccess: false;
+  status: "loading";
+  data: undefined;
+}
+
+export type UseAsyncErrorBoundaryOptions<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+> = Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, "suspense">;
+
+// In general, we can use `useQuery` in two ways.
+// I don't use it because I prefer the object syntax for `useQuery`.
+// The reason for preferring the object syntax is to ensure consistency, since the `useQueries` hook only supports object syntax.
+// export function useAsyncErrorBoundaryQuery<
+//   TQueryFnData = unknown,
+//   TError = unknown,
+//   TData = TQueryFnData,
+//   TQueryKey extends QueryKey = QueryKey
+// >(
+//   queryKey: TQueryKey,
+//   queryFn: QueryFunction<TQueryFnData, TQueryKey>,
+//   options?: Omit<
+//     UseAsyncErrorBoundaryOptions<TQueryFnData, TError, TData, TQueryKey>,
+//     "enabled" | "queryKey" | "queryFn"
+//   >
+// ): UseAsyncErrorBoundaryResultOnSuccess<TData>;
+
+export function useAsyncErrorBoundaryQuery<
   TQueryFnData = unknown,
   TError = unknown,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey
 >(
   options: Omit<
-    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-    "suspense"
+    UseAsyncErrorBoundaryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    "enabled"
   >
-): UseQueryResult<TData, TError> => {
-  return useQuery<TQueryFnData, TError, TData, TQueryKey>({
-    ...options,
+): UseAsyncErrorBoundaryResultOnSuccess<TQueryFnData>;
+
+/**
+ * It does not return errors or loading status, which are handled by the AsyncErrorBoundary component.
+ * By default, this has the same effect as setting the `suspense` option to `true`.
+ *
+ * used with {@link AsyncErrorBoundary}.
+ */
+export function useAsyncErrorBoundaryQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(arg1: UseAsyncErrorBoundaryOptions<TQueryFnData, TError, TData, TQueryKey>) {
+  return useQuery({
+    ...arg1,
     suspense: true,
-  });
-};
+  }) as BaseUseAsyncErrorBoundaryResult<TData>;
+}

--- a/src/pages/popup/index.tsx
+++ b/src/pages/popup/index.tsx
@@ -49,7 +49,7 @@ function init() {
               <Button
                 variant="contained"
                 color="primary"
-                onClick={() => resetErrorBoundary()}
+                onClick={resetErrorBoundary}
               >
                 다시 시도
               </Button>


### PR DESCRIPTION
- useAsyncErrorBoundary에서 loading, error 상태에 대한 처리를 함. 이는 사용하는 곳에서 성공 상태를 보장함.
- type narrowing 필요 x
- isFetching, isError, error 반환 x
- query hook 일관성 보장할 수 있도록 objecy syntax 사용 강제