### PR TITLE
fix(landing): prevent dark theme FOUC and respect system theme preference changes

### DIFF
--- a/src/landing/components/theme-toggle.tsx
+++ b/src/landing/components/theme-toggle.tsx
@@ -1,56 +1,73 @@
 import { motion, AnimatePresence } from 'motion/react';
-import IconSun from '~icons/lucide/sun';
-import IconMoon from '~icons/lucide/moon';
 
 import { Button } from '~/shared/components/ui/button';
 import { useSystemTheme } from '~/shared/hooks/use-system-theme';
 import { ANIMATION_DURATIONS } from '~/shared/lib/animations';
 
+import IconMoon from '~icons/lucide/moon';
+import IconSun from '~icons/lucide/sun';
+
 type Theme = 'light' | 'dark';
 
-function resolveInitialTheme(systemTheme: Theme): Theme {
-  if (typeof window === 'undefined') return systemTheme;
-  const stored = localStorage.getItem('landing-theme');
-  if (stored === 'light' || stored === 'dark') return stored;
-  return systemTheme;
+const THEME_STORAGE_KEY = 'landing-theme';
+
+function getStoredTheme(): Theme | null {
+  if (typeof window === 'undefined') return null;
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  return stored === 'light' || stored === 'dark' ? stored : null;
 }
 
-function applyTheme(theme: Theme) {
+function applyThemeToDOM(theme: Theme) {
   document.documentElement.classList.toggle('dark', theme === 'dark');
-  localStorage.setItem('landing-theme', theme);
+}
+
+function persistThemeChoice(theme: Theme) {
+  localStorage.setItem(THEME_STORAGE_KEY, theme);
 }
 
 export function ThemeToggle() {
   const systemTheme = useSystemTheme();
-  const [theme, setTheme] = useState<Theme>(() => resolveInitialTheme(systemTheme));
+  const [theme, setTheme] = useState<Theme>(() => getStoredTheme() ?? systemTheme);
+  const [isExplicit, setIsExplicit] = useState<boolean>(() => getStoredTheme() !== null);
 
   useEffect(() => {
-    applyTheme(theme);
+    applyThemeToDOM(theme);
   }, [theme]);
 
+  useEffect(() => {
+    if (!isExplicit) {
+      setTheme(systemTheme);
+    }
+  }, [systemTheme, isExplicit]);
+
   const toggle = useCallback(() => {
-    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+    setTheme((prev) => {
+      const next = prev === 'light' ? 'dark' : 'light';
+      persistThemeChoice(next);
+      setIsExplicit(true);
+      return next;
+    });
   }, []);
 
   const isDark = theme === 'dark';
 
   return (
     <Button
-      variant="ghost"
-      size="icon"
-      onClick={toggle}
       aria-label="Toggle dark mode"
+      className="relative overflow-hidden"
       data-umami-event="theme-toggle"
       data-umami-event-theme={isDark ? 'light' : 'dark'}
-      className="relative overflow-hidden"
+      size="icon"
+      variant="ghost"
+      onClick={toggle}
     >
-      <AnimatePresence mode="wait" initial={false}>
+      <AnimatePresence initial={false} mode="wait">
         {isDark ? (
           <motion.div
             key="moon"
-            initial={{ rotate: -180, opacity: 0 }}
             animate={{ rotate: 0, opacity: 1 }}
             exit={{ rotate: 180, opacity: 0 }}
+            initial={{ rotate: -180, opacity: 0 }}
             transition={{ duration: ANIMATION_DURATIONS.normal }}
           >
             <IconMoon className="size-5" />
@@ -58,9 +75,9 @@ export function ThemeToggle() {
         ) : (
           <motion.div
             key="sun"
-            initial={{ rotate: 180, opacity: 0 }}
             animate={{ rotate: 0, opacity: 1 }}
             exit={{ rotate: -180, opacity: 0 }}
+            initial={{ rotate: 180, opacity: 0 }}
             transition={{ duration: ANIMATION_DURATIONS.normal }}
           >
             <IconSun className="size-5" />


### PR DESCRIPTION
## Summary
- Prevent dark-theme flash on initial load by adding a blocking head script in `src/landing/index.html` that applies the `dark` class before render.
- Update `ThemeToggle` logic in `src/landing/components/theme-toggle.tsx` to separate auto-followed system theme from explicit user choice.
- Persist `landing-theme` only on explicit toggle clicks, so users who never chose a theme continue following OS `prefers-color-scheme` changes.

## Bug Fixes
### Bug 1: Dark mode FOUC
- Added synchronous theme initialization in `<head>` before analytics script.
- Logic checks localStorage first, then falls back to `prefers-color-scheme: dark`.

### Bug 2: System theme changes ignored after revisit
- Removed automatic persistence during theme application.
- Added explicit-choice tracking (`isExplicit`) so system theme changes continue syncing until user manually toggles.

## Verification
- `pnpm typecheck`
- `pnpm lint:fix`
- `pnpm test -- --run src/landing`
- `pnpm build`
- LSP diagnostics clean for changed files