### PR TITLE
chore: add i18n keys for sync suggestion replacement feature

### DIFF
--- a/extension/_locales/de/messages.json
+++ b/extension/_locales/de/messages.json
@@ -514,6 +514,18 @@
   "warningResetScrollOffsets": {
     "message": "Das Hinzufügen dieses Tabs setzt Ihre manuell angepasste Scrollposition zurück"
   },
+  "existingSyncWarning": {
+    "message": "Sie synchronisieren derzeit $COUNT$ Tabs. Dies wird die aktive Synchronisation ersetzen.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "replaceSyncButton": {
+    "message": "Ersetzen & Sync"
+  },
   "startSyncButton": {
     "message": "Sync starten"
   },

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -514,6 +514,18 @@
   "warningResetScrollOffsets": {
     "message": "Adding this tab will reset your scroll position adjustments"
   },
+  "existingSyncWarning": {
+    "message": "You're currently syncing $COUNT$ tabs. Starting this will replace the active sync.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "replaceSyncButton": {
+    "message": "Replace & Sync"
+  },
   "startSyncButton": {
     "message": "Start Sync"
   },

--- a/extension/_locales/es/messages.json
+++ b/extension/_locales/es/messages.json
@@ -514,6 +514,18 @@
   "warningResetScrollOffsets": {
     "message": "Agregar esta pestaña restablecerá los ajustes de posición de desplazamiento"
   },
+  "existingSyncWarning": {
+    "message": "Actualmente sincronizando $COUNT$ pestañas. Iniciar esto reemplazará la sincronización activa.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "replaceSyncButton": {
+    "message": "Reemplazar y Sincronizar"
+  },
   "startSyncButton": {
     "message": "Iniciar Sync"
   },

--- a/extension/_locales/fr/messages.json
+++ b/extension/_locales/fr/messages.json
@@ -514,6 +514,18 @@
   "warningResetScrollOffsets": {
     "message": "L'ajout de cet onglet réinitialisera vos ajustements de position de défilement"
   },
+  "existingSyncWarning": {
+    "message": "Vous synchronisez actuellement $COUNT$ onglets. Démarrer remplacera la synchronisation active.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "replaceSyncButton": {
+    "message": "Remplacer et Sync"
+  },
   "startSyncButton": {
     "message": "Démarrer Sync"
   },

--- a/extension/_locales/hi/messages.json
+++ b/extension/_locales/hi/messages.json
@@ -514,6 +514,18 @@
   "warningResetScrollOffsets": {
     "message": "इस टैब को जोड़ने से आपकी मैन्युअल स्क्रॉल स्थिति समायोजन रीसेट हो जाएंगी"
   },
+  "existingSyncWarning": {
+    "message": "वर्तमान में $COUNT$ टैब सिंक हो रहे हैं। इसे शुरू करने से सक्रिय सिंक बदल जाएगा।",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "replaceSyncButton": {
+    "message": "बदलें और सिंक करें"
+  },
   "startSyncButton": {
     "message": "सिंक शुरू करें"
   },

--- a/extension/_locales/ja/messages.json
+++ b/extension/_locales/ja/messages.json
@@ -514,6 +514,18 @@
   "warningResetScrollOffsets": {
     "message": "このタブを追加すると、手動で調整したスクロール位置がリセットされます"
   },
+  "existingSyncWarning": {
+    "message": "現在$COUNT$個のタブを同期中です。これを開始すると現在の同期が置き換えられます。",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "replaceSyncButton": {
+    "message": "置き換えて同期"
+  },
   "startSyncButton": {
     "message": "同期開始"
   },

--- a/extension/_locales/ko/messages.json
+++ b/extension/_locales/ko/messages.json
@@ -514,6 +514,18 @@
   "warningResetScrollOffsets": {
     "message": "이 탭을 추가하면 수동으로 조정한 스크롤 위치가 초기화됩니다"
   },
+  "existingSyncWarning": {
+    "message": "현재 $COUNT$개 탭을 동기화 중입니다. 이 동기화를 시작하면 기존 동기화가 중지됩니다.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "replaceSyncButton": {
+    "message": "교체 후 동기화"
+  },
   "startSyncButton": {
     "message": "동기화 시작"
   },

--- a/extension/_locales/zh_CN/messages.json
+++ b/extension/_locales/zh_CN/messages.json
@@ -514,6 +514,18 @@
   "warningResetScrollOffsets": {
     "message": "添加此标签页将重置您手动调整的滚动位置"
   },
+  "existingSyncWarning": {
+    "message": "当前正在同步$COUNT$个标签页。开始此操作将替换当前同步。",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "replaceSyncButton": {
+    "message": "替换并同步"
+  },
   "startSyncButton": {
     "message": "开始同步"
   },

--- a/extension/_locales/zh_TW/messages.json
+++ b/extension/_locales/zh_TW/messages.json
@@ -514,6 +514,18 @@
   "warningResetScrollOffsets": {
     "message": "新增此標籤頁將重設您手動調整的捲動位置"
   },
+  "existingSyncWarning": {
+    "message": "目前正在同步$COUNT$個標籤頁。開始此操作將取代目前的同步。",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "replaceSyncButton": {
+    "message": "取代並同步"
+  },
   "startSyncButton": {
     "message": "開始同步"
   },


### PR DESCRIPTION
## Summary

- Add `existingSyncWarning` and `replaceSyncButton` i18n keys to all 9 `extension/_locales/` files
- These keys are already present in `src/shared/i18n/_locales/` and used by `sync-suggestion-toast.tsx` — this commit syncs the browser runtime locale files to match

## Context

These keys support the sync suggestion replacement feature (amber warning banner + "Replace & Sync" button when sync is already active). The `extension/_locales/` side was missing while `src/shared/i18n/_locales/` already had them.