### PR TITLE
fix(landing): correct supported languages count from 10 to 9

### DIFF
--- a/src/landing/components/__tests__/language-selector.test.tsx
+++ b/src/landing/components/__tests__/language-selector.test.tsx
@@ -20,7 +20,7 @@ describe('LanguageToggle', () => {
     expect(trigger).toHaveAttribute('data-umami-event', 'language-toggle');
   });
 
-  it('opens dropdown and shows all 10 supported languages', async () => {
+  it('opens dropdown and shows all 9 supported languages', async () => {
     const user = userEvent.setup();
     render(<LanguageToggle />);
 

--- a/src/landing/lib/translations/de.ts
+++ b/src/landing/lib/translations/de.ts
@@ -109,7 +109,7 @@ const de: TranslationStrings = {
       noAnalytics: 'Keine Tracking-Cookies',
       offline: 'Funktioniert offline',
       openSource: 'Open Source',
-      languages: '10 Sprachen',
+      languages: '9 Sprachen',
       accessible: 'WCAG 2.1 AA',
     },
     browsers: 'Funktioniert in allen gängigen Browsern',

--- a/src/landing/lib/translations/en.ts
+++ b/src/landing/lib/translations/en.ts
@@ -106,7 +106,7 @@ const en: TranslationStrings = {
       noAnalytics: 'No tracking cookies',
       offline: 'Works offline',
       openSource: 'Open source',
-      languages: '10 languages',
+      languages: '9 languages',
       accessible: 'WCAG 2.1 AA',
     },
     browsers: 'Works on all major browsers',

--- a/src/landing/lib/translations/id.ts
+++ b/src/landing/lib/translations/id.ts
@@ -108,7 +108,7 @@ const id: TranslationStrings = {
       noAnalytics: 'Tanpa cookie pelacak',
       offline: 'Berfungsi offline',
       openSource: 'Sumber terbuka',
-      languages: '10 bahasa',
+      languages: '9 bahasa',
       accessible: 'WCAG 2.1 AA',
     },
     browsers: 'Berfungsi di semua browser utama',

--- a/src/landing/lib/translations/it.ts
+++ b/src/landing/lib/translations/it.ts
@@ -108,7 +108,7 @@ const it: TranslationStrings = {
       noAnalytics: 'Nessun cookie di tracciamento',
       offline: 'Funziona offline',
       openSource: 'Open source',
-      languages: '10 lingue',
+      languages: '9 lingue',
       accessible: 'WCAG 2.1 AA',
     },
     browsers: 'Funziona su tutti i principali browser',

--- a/src/landing/lib/translations/ko.ts
+++ b/src/landing/lib/translations/ko.ts
@@ -102,7 +102,7 @@ const ko: TranslationStrings = {
       noAnalytics: '추적 쿠키 없음',
       offline: '오프라인 작동',
       openSource: '오픈소스',
-      languages: '10개 언어 지원',
+      languages: '9개 언어 지원',
       accessible: 'WCAG 2.1 AA',
     },
     browsers: '모든 주요 브라우저에서 작동',

--- a/src/landing/lib/translations/pl.ts
+++ b/src/landing/lib/translations/pl.ts
@@ -107,7 +107,7 @@ const pl: TranslationStrings = {
       noAnalytics: 'Brak ciasteczek śledzących',
       offline: 'Działa offline',
       openSource: 'Otwarte źródło',
-      languages: '10 języków',
+      languages: '9 języków',
       accessible: 'WCAG 2.1 AA',
     },
     browsers: 'Działa we wszystkich głównych przeglądarkach',

--- a/src/landing/lib/translations/ru.ts
+++ b/src/landing/lib/translations/ru.ts
@@ -107,7 +107,7 @@ const ru: TranslationStrings = {
       noAnalytics: 'Без отслеживающих cookies',
       offline: 'Работает офлайн',
       openSource: 'Открытый код',
-      languages: '10 языков',
+      languages: '9 языков',
       accessible: 'WCAG 2.1 AA',
     },
     browsers: 'Работает во всех основных браузерах',

--- a/src/landing/lib/translations/tr.ts
+++ b/src/landing/lib/translations/tr.ts
@@ -107,7 +107,7 @@ const tr: TranslationStrings = {
       noAnalytics: 'İzleme çerezi yok',
       offline: 'Çevrimdışı çalışır',
       openSource: 'Açık kaynak',
-      languages: '10 dil',
+      languages: '9 dil',
       accessible: 'WCAG 2.1 AA',
     },
     browsers: 'Tüm büyük tarayıcılarda çalışır',

--- a/src/landing/lib/translations/vi.ts
+++ b/src/landing/lib/translations/vi.ts
@@ -104,7 +104,7 @@ const vi: TranslationStrings = {
       noAnalytics: 'Không cookie theo dõi',
       offline: 'Hoạt động ngoại tuyến',
       openSource: 'Mã nguồn mở',
-      languages: '10 ngôn ngữ',
+      languages: '9 ngôn ngữ',
       accessible: 'WCAG 2.1 AA',
     },
     browsers: 'Hoạt động trên tất cả trình duyệt phổ biến',

--- a/src/landing/lib/translations/zh_TW.ts
+++ b/src/landing/lib/translations/zh_TW.ts
@@ -98,7 +98,7 @@ const zh_TW: TranslationStrings = {
       noAnalytics: '無追蹤 Cookie',
       offline: '可離線使用',
       openSource: '開放原始碼',
-      languages: '10 種語言',
+      languages: '9 種語言',
       accessible: 'WCAG 2.1 AA',
     },
     browsers: '支援所有主流瀏覽器',


### PR DESCRIPTION
## Summary

- Landing page의 모든 번역 파일(10개 언어)에서 지원 언어 수를 "10"에서 "9"로 수정
- 실제 확장 프로그램은 9개 언어(en, ko, ja, fr, es, de, zh_CN, zh_TW, hi)를 지원하므로 landing page 표기와 일치시킴
- 관련 테스트(`language-selector.test.tsx`) 설명문도 함께 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Supported language count updated from 10 to 9. All language translations have been synchronized accordingly across the platform.

* **Tests**
  * Test suite updated to reflect the new supported language count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->