### PR TITLE
fix: animate command item leading indicator

### DIFF
--- a/docs/superpowers/specs/2026-04-30-command-item-highlight-design.md
+++ b/docs/superpowers/specs/2026-04-30-command-item-highlight-design.md
@@ -1,0 +1,66 @@
+# Command Item Highlight Design
+
+## Context
+
+Windows users cannot reliably see the active option in popup command lists when hovering with a
+mouse or navigating with the keyboard. The same UI is visible on macOS, so this should preserve the
+existing visual language instead of introducing a new highlight color.
+
+The affected surfaces share the `CommandItem` primitive:
+
+- `TabCommandPalette`: tab search and selection list.
+- `ActionsMenu`: command-style action menu.
+
+## Goal
+
+Make hover and keyboard-active command items visibly use the existing accent highlight on Windows,
+matching the macOS behavior as closely as the shared design tokens allow.
+
+## Non-Goals
+
+- Do not introduce a new color, theme token, or platform-specific palette.
+- Do not redesign popup layout, spacing, typography, or selected-tab behavior.
+- Do not change scroll-sync state, tab discovery, or action execution behavior.
+
+## Design
+
+Update the shared `CommandItem` styling in `src/shared/components/ui/command.tsx` so the item uses
+the existing `bg-accent` and `text-accent-foreground` tokens for both mouse hover and cmdk's
+keyboard-active state (`data-selected=true`).
+
+This keeps the fix centralized. Every current and future popup command list receives the same
+interaction feedback without repeating hover classes in individual components.
+
+`TabCommandPalette` should keep its current selected-tab logic. The checkbox/checkmark represents
+whether a tab is selected for sync. The command highlight represents the row currently hovered or
+keyboard-active. These states can overlap, but the implementation should not add a separate
+selected-tab color.
+
+## Accessibility
+
+The visible active row is required for keyboard users because arrow-key navigation depends on
+knowing which option is active before pressing Enter. The shared command item should therefore
+expose a visible state for:
+
+- Mouse hover.
+- cmdk keyboard navigation via `data-selected=true`.
+- Existing disabled state, which must remain visually muted and non-interactive.
+
+## Testing
+
+Add focused regression coverage around the shared `CommandItem` contract. The test should verify
+that the component includes the shared hover and `data-selected=true` accent classes so both
+`TabCommandPalette` and `ActionsMenu` inherit the fix.
+
+Run at least:
+
+- A targeted Vitest command for the affected component or popup tests.
+- `pnpm typecheck`.
+
+## Acceptance Criteria
+
+- Hovering a tab row or action menu item visibly highlights it on Windows light mode.
+- Arrow-key navigation visibly highlights the cmdk-active row on Windows light mode.
+- Dark mode continues to use the existing accent tokens.
+- No new colors or theme tokens are introduced.
+- The fix is shared through `CommandItem`, not duplicated across popup call sites.

--- a/docs/superpowers/specs/2026-05-15-command-item-leading-indicator-design.md
+++ b/docs/superpowers/specs/2026-05-15-command-item-leading-indicator-design.md
@@ -1,0 +1,105 @@
+# Command Item Leading Indicator Design
+
+## Context
+
+The previous `CommandItem` highlight fix made hover state use the existing accent background.
+That improved state consistency, but it still depended on a subtle light-gray background tint.
+Real device testing showed the tint can disappear on a QHD gaming monitor while remaining visible
+on a 4K Mac-oriented monitor.
+
+The failure mode is therefore not only OS-specific. It is a display-contrast and rendering problem:
+active rows must not rely on a low-contrast background color alone.
+
+This design supersedes `2026-04-30-command-item-highlight-design.md`.
+
+## Goal
+
+Make the active command row identifiable on lower-contrast displays by adding a non-color-field
+structural cue: a leading indicator on the active row.
+
+The affected surfaces still share the `CommandItem` primitive:
+
+- `TabCommandPalette`: tab search and selection list.
+- `ActionsMenu`: command-style action menu.
+
+## Non-Goals
+
+- Do not introduce a new theme color, custom hex color, or monitor-specific palette.
+- Do not darken global `--accent`, `--muted`, or other theme tokens.
+- Do not add platform, browser, or monitor detection.
+- Do not redesign popup layout, typography, or tab selection behavior.
+- Do not change scroll-sync state, tab discovery, or action execution behavior.
+
+## Design
+
+Replace the hover-only accent-background fix with a shared leading indicator in
+`src/shared/components/ui/command.tsx`.
+
+The active row should keep the existing `data-[selected='true']:bg-accent` keyboard-active
+background as a secondary cue, but the reliable primary cue should be a leading bar rendered inside
+the command item. The leading bar should:
+
+- Appear on mouse hover.
+- Appear when cmdk marks the item as keyboard-active via `data-selected=true`.
+- Use the existing high-contrast semantic token `foreground`.
+- Be implemented without layout shift as an absolutely positioned pseudo-element.
+- Stay hidden for disabled command items.
+
+This keeps the behavior centralized. Current and future command-list surfaces inherit the same
+monitor-safe active-row cue without repeating popup-specific classes.
+
+`TabCommandPalette` should keep its current selected-tab logic. The checkbox/checkmark still means
+"selected for sync." The leading indicator means "currently hovered or keyboard-active." These
+states can overlap, but the implementation should not add a separate selected-tab color.
+
+## Accessibility
+
+WCAG guidance for non-text contrast and focus appearance supports using visible indicators that do
+not depend on barely distinguishable color fields. For this component, a leading indicator gives
+keyboard and pointer users a shape-based cue even when the background tint is not perceptible on a
+specific monitor.
+
+The active command item should therefore expose a visible state for:
+
+- Mouse hover.
+- cmdk keyboard navigation via `data-selected=true`.
+- Disabled state, which must remain visually muted and non-interactive.
+
+## Testing
+
+Update regression coverage around the shared `CommandItem` class contract. The test should verify
+that the shared primitive includes:
+
+- Existing keyboard-active background classes.
+- Existing disabled-state classes.
+- Leading-indicator pseudo-element base classes.
+- Hover and `data-selected=true` classes that reveal the leading indicator.
+- Disabled-state classes that keep the indicator hidden.
+
+The test should stop treating `hover:bg-accent` as the core acceptance criterion. The reliable
+acceptance criterion is the non-color-field leading indicator.
+
+Run at least:
+
+- A targeted Vitest command for `CommandItem`.
+- `pnpm typecheck`.
+- `git diff --check`.
+
+## PR Handling
+
+The existing draft PR should be revised rather than shipped as-is:
+
+- Remove the hover-only `CommandItem` implementation added by the prior fix.
+- Replace the prior test assertions that only check hover accent background.
+- Keep or update documentation so the shipped PR does not claim subtle accent tint alone is
+  sufficient.
+
+## Acceptance Criteria
+
+- Hovering a tab row or action menu item shows a visible leading indicator.
+- Arrow-key navigation shows the same leading indicator on the cmdk-active row.
+- The indicator remains visible on lower-contrast displays where the accent background is hard to
+  distinguish.
+- The implementation uses existing semantic tokens and introduces no new color palette.
+- The fix is shared through `CommandItem`, not duplicated across popup call sites.
+- Disabled command items do not show an active-row indicator.

--- a/src/shared/components/ui/command.test.tsx
+++ b/src/shared/components/ui/command.test.tsx
@@ -115,6 +115,7 @@ describe('CommandItem', () => {
     await waitFor(() => {
       expect(enabledOption.querySelector(INDICATOR_SELECTOR)).not.toBeNull();
     });
+    enabledOption.setAttribute('data-selected', 'true');
     expect(getIndicatorCount()).toBe(1);
 
     disabledOption.setAttribute('data-selected', 'true');
@@ -128,7 +129,7 @@ describe('CommandItem', () => {
     expect(disabledOption.className).toContain('data-[disabled=true]:cursor-not-allowed');
     expect(disabledOption.className).toContain('data-[disabled=true]:opacity-50');
 
-    fireEvent.pointerEnter(enabledOption);
+    fireEvent.pointerLeave(disabledOption);
 
     await waitFor(() => {
       expect(enabledOption.querySelector(INDICATOR_SELECTOR)).not.toBeNull();

--- a/src/shared/components/ui/command.test.tsx
+++ b/src/shared/components/ui/command.test.tsx
@@ -18,7 +18,7 @@ if (!globalThis.ResizeObserver) {
 Element.prototype.scrollIntoView = vi.fn();
 
 describe('CommandItem', () => {
-  it('uses existing accent tokens for hover and keyboard-active states', () => {
+  it('uses a non-color leading indicator for hover and keyboard-active states', () => {
     render(
       <Command>
         <CommandList>
@@ -29,10 +29,24 @@ describe('CommandItem', () => {
 
     const item = screen.getByRole('option', { name: 'Open tab' });
 
-    expect(item.className).toContain('hover:bg-accent');
-    expect(item.className).toContain('hover:text-accent-foreground');
+    expect(item.className).not.toContain('hover:bg-accent');
+    expect(item.className).not.toContain('hover:text-accent-foreground');
     expect(item.className).toContain("data-[selected='true']:bg-accent");
     expect(item.className).toContain('data-[selected=true]:text-accent-foreground');
+    expect(item.className).toContain("before:content-['']");
+    expect(item.className).toContain('before:absolute');
+    expect(item.className).toContain('before:left-0');
+    expect(item.className).toContain('before:top-1.5');
+    expect(item.className).toContain('before:bottom-1.5');
+    expect(item.className).toContain('before:w-1');
+    expect(item.className).toContain('before:rounded-r-sm');
+    expect(item.className).toContain('before:bg-foreground');
+    expect(item.className).toContain('before:opacity-0');
+    expect(item.className).toContain('before:transition-opacity');
+    expect(item.className).toContain('hover:before:opacity-100');
+    expect(item.className).toContain('data-[selected=true]:before:opacity-100');
+    expect(item.className).toContain('data-[disabled=true]:before:opacity-0');
+    expect(item.className).toContain('data-[disabled=true]:data-[selected=true]:before:opacity-0');
     expect(item.className).toContain('data-[disabled=true]:pointer-events-none');
     expect(item.className).toContain('data-[disabled=true]:opacity-50');
   });

--- a/src/shared/components/ui/command.test.tsx
+++ b/src/shared/components/ui/command.test.tsx
@@ -43,6 +43,9 @@ describe('CommandItem', () => {
     await waitFor(() => {
       expect(previousItem.querySelector(INDICATOR_SELECTOR)).not.toBeNull();
     });
+    expect(previousItem.querySelector(INDICATOR_SELECTOR)?.getAttribute('data-motion-mode')).toBe(
+      'instant',
+    );
     expect(getIndicatorCount()).toBe(1);
 
     fireEvent.pointerEnter(nextItem);
@@ -54,6 +57,9 @@ describe('CommandItem', () => {
     expect(getIndicatorCount()).toBe(1);
     expect(nextItem.querySelector(INDICATOR_SELECTOR)?.getAttribute('data-layout-id')).toBe(
       'command-item-leading-indicator',
+    );
+    expect(nextItem.querySelector(INDICATOR_SELECTOR)?.getAttribute('data-motion-mode')).toBe(
+      'animated',
     );
   });
 
@@ -73,6 +79,9 @@ describe('CommandItem', () => {
     await waitFor(() => {
       expect(firstOption.querySelector(INDICATOR_SELECTOR)).not.toBeNull();
     });
+    expect(firstOption.querySelector(INDICATOR_SELECTOR)?.getAttribute('data-motion-mode')).toBe(
+      'instant',
+    );
     expect(getIndicatorCount()).toBe(1);
 
     secondOption.setAttribute('data-selected', 'true');
@@ -82,6 +91,9 @@ describe('CommandItem', () => {
       expect(secondOption.querySelector(INDICATOR_SELECTOR)).not.toBeNull();
     });
     expect(firstOption.querySelector(INDICATOR_SELECTOR)).toBeNull();
+    expect(secondOption.querySelector(INDICATOR_SELECTOR)?.getAttribute('data-motion-mode')).toBe(
+      'instant',
+    );
     expect(getIndicatorCount()).toBe(1);
   });
 

--- a/src/shared/components/ui/command.test.tsx
+++ b/src/shared/components/ui/command.test.tsx
@@ -92,7 +92,7 @@ describe('CommandItem', () => {
     });
     expect(firstOption.querySelector(INDICATOR_SELECTOR)).toBeNull();
     expect(secondOption.querySelector(INDICATOR_SELECTOR)?.getAttribute('data-motion-mode')).toBe(
-      'instant',
+      'animated',
     );
     expect(getIndicatorCount()).toBe(1);
   });

--- a/src/shared/components/ui/command.test.tsx
+++ b/src/shared/components/ui/command.test.tsx
@@ -1,0 +1,39 @@
+/// <reference types="vitest/globals" />
+
+import { render, screen } from '@testing-library/react';
+
+import { Command, CommandItem, CommandList } from './command';
+
+if (!globalThis.ResizeObserver) {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+}
+
+Element.prototype.scrollIntoView = vi.fn();
+
+describe('CommandItem', () => {
+  it('uses existing accent tokens for hover and keyboard-active states', () => {
+    render(
+      <Command>
+        <CommandList>
+          <CommandItem>Open tab</CommandItem>
+        </CommandList>
+      </Command>,
+    );
+
+    const item = screen.getByRole('option', { name: 'Open tab' });
+
+    expect(item.className).toContain('hover:bg-accent');
+    expect(item.className).toContain('hover:text-accent-foreground');
+    expect(item.className).toContain("data-[selected='true']:bg-accent");
+    expect(item.className).toContain('data-[selected=true]:text-accent-foreground');
+    expect(item.className).toContain('data-[disabled=true]:pointer-events-none');
+    expect(item.className).toContain('data-[disabled=true]:opacity-50');
+  });
+});

--- a/src/shared/components/ui/command.test.tsx
+++ b/src/shared/components/ui/command.test.tsx
@@ -1,8 +1,10 @@
 /// <reference types="vitest/globals" />
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { Command, CommandItem, CommandList } from './command';
+
+const INDICATOR_SELECTOR = '[data-slot="command-item-leading-indicator"]';
 
 if (!globalThis.ResizeObserver) {
   vi.stubGlobal(
@@ -17,37 +19,109 @@ if (!globalThis.ResizeObserver) {
 
 Element.prototype.scrollIntoView = vi.fn();
 
+function getIndicatorCount() {
+  return document.querySelectorAll(INDICATOR_SELECTOR).length;
+}
+
 describe('CommandItem', () => {
-  it('uses a non-color leading indicator for hover and keyboard-active states', () => {
+  it('moves one shared leading indicator from the selected item to the hovered item', async () => {
     render(
       <Command>
         <CommandList>
-          <CommandItem>Open tab</CommandItem>
+          <CommandItem>Previous item</CommandItem>
+          <CommandItem>Next item</CommandItem>
         </CommandList>
       </Command>,
     );
 
-    const item = screen.getByRole('option', { name: 'Open tab' });
+    const previousItem = screen.getByRole('option', { name: 'Previous item' });
+    const nextItem = screen.getByRole('option', { name: 'Next item' });
 
-    expect(item.className).not.toContain('hover:bg-accent');
-    expect(item.className).not.toContain('hover:text-accent-foreground');
-    expect(item.className).toContain("data-[selected='true']:bg-accent");
-    expect(item.className).toContain('data-[selected=true]:text-accent-foreground');
-    expect(item.className).toContain("before:content-['']");
-    expect(item.className).toContain('before:absolute');
-    expect(item.className).toContain('before:left-0');
-    expect(item.className).toContain('before:top-1.5');
-    expect(item.className).toContain('before:bottom-1.5');
-    expect(item.className).toContain('before:w-1');
-    expect(item.className).toContain('before:rounded-r-sm');
-    expect(item.className).toContain('before:bg-foreground');
-    expect(item.className).toContain('before:opacity-0');
-    expect(item.className).toContain('before:transition-opacity');
-    expect(item.className).toContain('hover:before:opacity-100');
-    expect(item.className).toContain('data-[selected=true]:before:opacity-100');
-    expect(item.className).toContain('data-[disabled=true]:before:opacity-0');
-    expect(item.className).toContain('data-[disabled=true]:data-[selected=true]:before:opacity-0');
-    expect(item.className).toContain('data-[disabled=true]:pointer-events-none');
-    expect(item.className).toContain('data-[disabled=true]:opacity-50');
+    expect(previousItem.className).not.toContain('before:');
+    expect(nextItem.className).not.toContain('before:');
+
+    await waitFor(() => {
+      expect(previousItem.querySelector(INDICATOR_SELECTOR)).not.toBeNull();
+    });
+    expect(getIndicatorCount()).toBe(1);
+
+    fireEvent.pointerEnter(nextItem);
+
+    await waitFor(() => {
+      expect(nextItem.querySelector(INDICATOR_SELECTOR)).not.toBeNull();
+    });
+    expect(previousItem.querySelector(INDICATOR_SELECTOR)).toBeNull();
+    expect(getIndicatorCount()).toBe(1);
+    expect(nextItem.querySelector(INDICATOR_SELECTOR)?.getAttribute('data-layout-id')).toBe(
+      'command-item-leading-indicator',
+    );
+  });
+
+  it('moves the shared indicator when cmdk changes the selected item', async () => {
+    render(
+      <Command>
+        <CommandList>
+          <CommandItem>First option</CommandItem>
+          <CommandItem>Second option</CommandItem>
+        </CommandList>
+      </Command>,
+    );
+
+    const firstOption = screen.getByRole('option', { name: 'First option' });
+    const secondOption = screen.getByRole('option', { name: 'Second option' });
+
+    await waitFor(() => {
+      expect(firstOption.querySelector(INDICATOR_SELECTOR)).not.toBeNull();
+    });
+    expect(getIndicatorCount()).toBe(1);
+
+    secondOption.setAttribute('data-selected', 'true');
+    firstOption.setAttribute('data-selected', 'false');
+
+    await waitFor(() => {
+      expect(secondOption.querySelector(INDICATOR_SELECTOR)).not.toBeNull();
+    });
+    expect(firstOption.querySelector(INDICATOR_SELECTOR)).toBeNull();
+    expect(getIndicatorCount()).toBe(1);
+  });
+
+  it('removes the moving indicator when a disabled item becomes selected or hovered', async () => {
+    render(
+      <Command>
+        <CommandList>
+          <CommandItem>Enabled option</CommandItem>
+          <CommandItem disabled>Disabled option</CommandItem>
+        </CommandList>
+      </Command>,
+    );
+
+    const enabledOption = screen.getByRole('option', { name: 'Enabled option' });
+    const disabledOption = screen.getByRole('option', { name: 'Disabled option' });
+
+    fireEvent.pointerEnter(enabledOption);
+
+    await waitFor(() => {
+      expect(enabledOption.querySelector(INDICATOR_SELECTOR)).not.toBeNull();
+    });
+    expect(getIndicatorCount()).toBe(1);
+
+    disabledOption.setAttribute('data-selected', 'true');
+    fireEvent.pointerEnter(disabledOption);
+
+    await waitFor(() => {
+      expect(getIndicatorCount()).toBe(0);
+    });
+    expect(enabledOption.querySelector(INDICATOR_SELECTOR)).toBeNull();
+    expect(disabledOption.querySelector(INDICATOR_SELECTOR)).toBeNull();
+    expect(disabledOption.className).toContain('data-[disabled=true]:cursor-not-allowed');
+    expect(disabledOption.className).toContain('data-[disabled=true]:opacity-50');
+
+    fireEvent.pointerEnter(enabledOption);
+
+    await waitFor(() => {
+      expect(enabledOption.querySelector(INDICATOR_SELECTOR)).not.toBeNull();
+    });
+    expect(disabledOption.querySelector(INDICATOR_SELECTOR)).toBeNull();
+    expect(getIndicatorCount()).toBe(1);
   });
 });

--- a/src/shared/components/ui/command.tsx
+++ b/src/shared/components/ui/command.tsx
@@ -5,11 +5,7 @@ import { Command as CommandPrimitive } from 'cmdk';
 import { LayoutGroup, motion } from 'motion/react';
 
 import { Dialog, DialogContent } from '~/shared/components/ui/dialog';
-import {
-  ANIMATION_DURATIONS,
-  EASING_FUNCTIONS,
-  getMotionTransition,
-} from '~/shared/lib/animations';
+import { getMotionSpringTransition } from '~/shared/lib/animations';
 import { cn } from '~/shared/lib/utils';
 
 import IconSearch from '~icons/lucide/search';
@@ -320,9 +316,7 @@ function CommandItem({
   const indicatorMotionMode =
     indicatorContext?.activeItemSource === 'pointer' ? 'animated' : 'instant';
   const indicatorTransition =
-    indicatorMotionMode === 'animated'
-      ? getMotionTransition(ANIMATION_DURATIONS.fast, EASING_FUNCTIONS.easeOutCubic)
-      : { duration: 0 };
+    indicatorMotionMode === 'animated' ? getMotionSpringTransition() : { duration: 0 };
 
   return (
     <CommandPrimitive.Item

--- a/src/shared/components/ui/command.tsx
+++ b/src/shared/components/ui/command.tsx
@@ -16,8 +16,11 @@ import IconSearch from '~icons/lucide/search';
 
 const COMMAND_ITEM_INDICATOR_LAYOUT_ID = 'command-item-leading-indicator';
 
+type CommandIndicatorSource = 'pointer' | 'selected';
+
 interface CommandIndicatorContextValue {
   activeItemId: string | null;
+  activeItemSource: CommandIndicatorSource | null;
   setPointerItemId: React.Dispatch<React.SetStateAction<string | null>>;
   setPointerDisabledItemId: React.Dispatch<React.SetStateAction<string | null>>;
   setSelectedItemId: React.Dispatch<React.SetStateAction<string | null>>;
@@ -45,15 +48,23 @@ function Command({ ref, className, ...props }: CommandProps) {
   const [pointerDisabledItemId, setPointerDisabledItemId] = React.useState<string | null>(null);
   const [selectedItemId, setSelectedItemId] = React.useState<string | null>(null);
   const activeItemId = pointerDisabledItemId ? null : (pointerItemId ?? selectedItemId);
+  const activeItemSource: CommandIndicatorSource | null = pointerDisabledItemId
+    ? null
+    : pointerItemId
+      ? 'pointer'
+      : selectedItemId
+        ? 'selected'
+        : null;
   const layoutGroupId = React.useId();
   const indicatorContext = React.useMemo(
     () => ({
       activeItemId,
+      activeItemSource,
       setPointerItemId,
       setPointerDisabledItemId,
       setSelectedItemId,
     }),
-    [activeItemId],
+    [activeItemId, activeItemSource],
   );
 
   return (
@@ -306,6 +317,12 @@ function CommandItem({
   );
 
   const isIndicatorActive = indicatorContext?.activeItemId === itemId && !isItemDisabled();
+  const indicatorMotionMode =
+    indicatorContext?.activeItemSource === 'pointer' ? 'animated' : 'instant';
+  const indicatorTransition =
+    indicatorMotionMode === 'animated'
+      ? getMotionTransition(ANIMATION_DURATIONS.fast, EASING_FUNCTIONS.easeOutCubic)
+      : { duration: 0 };
 
   return (
     <CommandPrimitive.Item
@@ -324,9 +341,10 @@ function CommandItem({
           aria-hidden="true"
           className="pointer-events-none absolute left-0 top-1.5 bottom-1.5 w-1 rounded-r-sm bg-foreground"
           data-layout-id={COMMAND_ITEM_INDICATOR_LAYOUT_ID}
+          data-motion-mode={indicatorMotionMode}
           data-slot="command-item-leading-indicator"
           layoutId={COMMAND_ITEM_INDICATOR_LAYOUT_ID}
-          transition={getMotionTransition(ANIMATION_DURATIONS.fast, EASING_FUNCTIONS.easeOutCubic)}
+          transition={indicatorTransition}
         />
       )}
       {props.children}

--- a/src/shared/components/ui/command.tsx
+++ b/src/shared/components/ui/command.tsx
@@ -12,11 +12,9 @@ import IconSearch from '~icons/lucide/search';
 
 const COMMAND_ITEM_INDICATOR_LAYOUT_ID = 'command-item-leading-indicator';
 
-type CommandIndicatorSource = 'pointer' | 'selected';
-
 interface CommandIndicatorContextValue {
   activeItemId: string | null;
-  activeItemSource: CommandIndicatorSource | null;
+  shouldAnimateActiveItem: boolean;
   setPointerItemId: React.Dispatch<React.SetStateAction<string | null>>;
   setPointerDisabledItemId: React.Dispatch<React.SetStateAction<string | null>>;
   setSelectedItemId: React.Dispatch<React.SetStateAction<string | null>>;
@@ -43,25 +41,25 @@ function Command({ ref, className, ...props }: CommandProps) {
   const [pointerItemId, setPointerItemId] = React.useState<string | null>(null);
   const [pointerDisabledItemId, setPointerDisabledItemId] = React.useState<string | null>(null);
   const [selectedItemId, setSelectedItemId] = React.useState<string | null>(null);
+  const previousActiveItemId = React.useRef<string | null>(null);
   const activeItemId = pointerDisabledItemId ? null : (pointerItemId ?? selectedItemId);
-  const activeItemSource: CommandIndicatorSource | null = pointerDisabledItemId
-    ? null
-    : pointerItemId
-      ? 'pointer'
-      : selectedItemId
-        ? 'selected'
-        : null;
+  const shouldAnimateActiveItem =
+    previousActiveItemId.current !== null && previousActiveItemId.current !== activeItemId;
   const layoutGroupId = React.useId();
   const indicatorContext = React.useMemo(
     () => ({
       activeItemId,
-      activeItemSource,
+      shouldAnimateActiveItem,
       setPointerItemId,
       setPointerDisabledItemId,
       setSelectedItemId,
     }),
-    [activeItemId, activeItemSource],
+    [activeItemId, shouldAnimateActiveItem],
   );
+
+  React.useLayoutEffect(() => {
+    previousActiveItemId.current = activeItemId;
+  }, [activeItemId]);
 
   return (
     <CommandIndicatorContext.Provider value={indicatorContext}>
@@ -313,8 +311,7 @@ function CommandItem({
   );
 
   const isIndicatorActive = indicatorContext?.activeItemId === itemId && !isItemDisabled();
-  const indicatorMotionMode =
-    indicatorContext?.activeItemSource === 'pointer' ? 'animated' : 'instant';
+  const indicatorMotionMode = indicatorContext?.shouldAnimateActiveItem ? 'animated' : 'instant';
   const indicatorTransition =
     indicatorMotionMode === 'animated' ? getMotionSpringTransition() : { duration: 0 };
 

--- a/src/shared/components/ui/command.tsx
+++ b/src/shared/components/ui/command.tsx
@@ -145,7 +145,7 @@ function CommandItem({ ref, className, ...props }: CommandItemProps) {
     <CommandPrimitive.Item
       ref={ref}
       className={cn(
-        "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 before:content-[''] before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-1 before:rounded-r-sm before:bg-foreground before:opacity-0 before:transition-opacity hover:before:opacity-100 data-[selected=true]:before:opacity-100 data-[disabled=true]:before:opacity-0 data-[disabled=true]:data-[selected=true]:before:opacity-0 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
         className,
       )}
       {...props}

--- a/src/shared/components/ui/command.tsx
+++ b/src/shared/components/ui/command.tsx
@@ -277,7 +277,6 @@ function CommandItem({
       if (!event.defaultPrevented) {
         if (isItemDisabled()) {
           setPointerItemId?.((currentItemId) => (currentItemId === itemId ? null : currentItemId));
-          setSelectedItemId?.((currentItemId) => (currentItemId === itemId ? null : currentItemId));
           setPointerDisabledItemId?.(itemId);
           return;
         }
@@ -286,14 +285,7 @@ function CommandItem({
         setPointerItemId?.(itemId);
       }
     },
-    [
-      isItemDisabled,
-      itemId,
-      onPointerEnter,
-      setPointerDisabledItemId,
-      setPointerItemId,
-      setSelectedItemId,
-    ],
+    [isItemDisabled, itemId, onPointerEnter, setPointerDisabledItemId, setPointerItemId],
   );
 
   const handlePointerLeave = React.useCallback(
@@ -319,7 +311,7 @@ function CommandItem({
     <CommandPrimitive.Item
       ref={setItemRef}
       className={cn(
-        "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:cursor-not-allowed data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        'relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:cursor-not-allowed data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
         className,
       )}
       disabled={disabled}

--- a/src/shared/components/ui/command.tsx
+++ b/src/shared/components/ui/command.tsx
@@ -2,26 +2,73 @@ import * as React from 'react';
 
 import { type DialogProps } from '@radix-ui/react-dialog';
 import { Command as CommandPrimitive } from 'cmdk';
+import { LayoutGroup, motion } from 'motion/react';
 
 import { Dialog, DialogContent } from '~/shared/components/ui/dialog';
+import {
+  ANIMATION_DURATIONS,
+  EASING_FUNCTIONS,
+  getMotionTransition,
+} from '~/shared/lib/animations';
 import { cn } from '~/shared/lib/utils';
 
 import IconSearch from '~icons/lucide/search';
+
+const COMMAND_ITEM_INDICATOR_LAYOUT_ID = 'command-item-leading-indicator';
+
+interface CommandIndicatorContextValue {
+  activeItemId: string | null;
+  setPointerItemId: React.Dispatch<React.SetStateAction<string | null>>;
+  setPointerDisabledItemId: React.Dispatch<React.SetStateAction<string | null>>;
+  setSelectedItemId: React.Dispatch<React.SetStateAction<string | null>>;
+}
+
+const CommandIndicatorContext = React.createContext<CommandIndicatorContextValue | null>(null);
+
+function setRef<T>(ref: React.Ref<T> | undefined, value: T | null) {
+  if (typeof ref === 'function') {
+    ref(value);
+    return;
+  }
+
+  if (ref) {
+    ref.current = value;
+  }
+}
 
 export interface CommandProps extends React.ComponentPropsWithoutRef<typeof CommandPrimitive> {
   ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive>>;
 }
 
 function Command({ ref, className, ...props }: CommandProps) {
+  const [pointerItemId, setPointerItemId] = React.useState<string | null>(null);
+  const [pointerDisabledItemId, setPointerDisabledItemId] = React.useState<string | null>(null);
+  const [selectedItemId, setSelectedItemId] = React.useState<string | null>(null);
+  const activeItemId = pointerDisabledItemId ? null : (pointerItemId ?? selectedItemId);
+  const layoutGroupId = React.useId();
+  const indicatorContext = React.useMemo(
+    () => ({
+      activeItemId,
+      setPointerItemId,
+      setPointerDisabledItemId,
+      setSelectedItemId,
+    }),
+    [activeItemId],
+  );
+
   return (
-    <CommandPrimitive
-      ref={ref}
-      className={cn(
-        'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
-        className,
-      )}
-      {...props}
-    />
+    <CommandIndicatorContext.Provider value={indicatorContext}>
+      <LayoutGroup id={layoutGroupId}>
+        <CommandPrimitive
+          ref={ref}
+          className={cn(
+            'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
+            className,
+          )}
+          {...props}
+        />
+      </LayoutGroup>
+    </CommandIndicatorContext.Provider>
   );
 }
 Command.displayName = CommandPrimitive.displayName;
@@ -140,16 +187,150 @@ export interface CommandItemProps extends React.ComponentPropsWithoutRef<
   ref?: React.Ref<React.ComponentRef<typeof CommandPrimitive.Item>>;
 }
 
-function CommandItem({ ref, className, ...props }: CommandItemProps) {
+function CommandItem({
+  ref,
+  className,
+  disabled,
+  onPointerEnter,
+  onPointerLeave,
+  ...props
+}: CommandItemProps) {
+  const indicatorContext = React.useContext(CommandIndicatorContext);
+  const itemId = React.useId();
+  const itemRef = React.useRef<React.ComponentRef<typeof CommandPrimitive.Item>>(null);
+  const setPointerItemId = indicatorContext?.setPointerItemId;
+  const setPointerDisabledItemId = indicatorContext?.setPointerDisabledItemId;
+  const setSelectedItemId = indicatorContext?.setSelectedItemId;
+
+  const setItemRef = React.useCallback(
+    (node: React.ComponentRef<typeof CommandPrimitive.Item> | null) => {
+      itemRef.current = node;
+      setRef(ref, node);
+    },
+    [ref],
+  );
+
+  const isItemDisabled = React.useCallback(() => {
+    return disabled === true || itemRef.current?.getAttribute('data-disabled') === 'true';
+  }, [disabled]);
+
+  const syncSelectedState = React.useCallback(() => {
+    if (!setPointerItemId || !setSelectedItemId) {
+      return;
+    }
+
+    if (isItemDisabled()) {
+      setPointerItemId((currentItemId) => (currentItemId === itemId ? null : currentItemId));
+      setSelectedItemId((currentItemId) => (currentItemId === itemId ? null : currentItemId));
+      return;
+    }
+
+    setPointerDisabledItemId?.((currentItemId) =>
+      currentItemId === itemId ? null : currentItemId,
+    );
+
+    const isSelected = itemRef.current?.getAttribute('data-selected') === 'true';
+
+    setSelectedItemId((currentItemId) => {
+      if (isSelected) {
+        return itemId;
+      }
+
+      return currentItemId === itemId ? null : currentItemId;
+    });
+  }, [isItemDisabled, itemId, setPointerDisabledItemId, setPointerItemId, setSelectedItemId]);
+
+  React.useEffect(() => {
+    const item = itemRef.current;
+
+    if (!item || !setPointerItemId || !setSelectedItemId) {
+      return;
+    }
+
+    syncSelectedState();
+
+    const observer = new MutationObserver(syncSelectedState);
+    observer.observe(item, {
+      attributeFilter: ['data-disabled', 'data-selected'],
+      attributes: true,
+    });
+
+    return () => {
+      observer.disconnect();
+      setPointerItemId((currentItemId) => (currentItemId === itemId ? null : currentItemId));
+      setPointerDisabledItemId?.((currentItemId) =>
+        currentItemId === itemId ? null : currentItemId,
+      );
+      setSelectedItemId((currentItemId) => (currentItemId === itemId ? null : currentItemId));
+    };
+  }, [itemId, setPointerDisabledItemId, setPointerItemId, setSelectedItemId, syncSelectedState]);
+
+  const handlePointerEnter = React.useCallback(
+    (event: React.PointerEvent<React.ComponentRef<typeof CommandPrimitive.Item>>) => {
+      onPointerEnter?.(event);
+
+      if (!event.defaultPrevented) {
+        if (isItemDisabled()) {
+          setPointerItemId?.((currentItemId) => (currentItemId === itemId ? null : currentItemId));
+          setSelectedItemId?.((currentItemId) => (currentItemId === itemId ? null : currentItemId));
+          setPointerDisabledItemId?.(itemId);
+          return;
+        }
+
+        setPointerDisabledItemId?.(null);
+        setPointerItemId?.(itemId);
+      }
+    },
+    [
+      isItemDisabled,
+      itemId,
+      onPointerEnter,
+      setPointerDisabledItemId,
+      setPointerItemId,
+      setSelectedItemId,
+    ],
+  );
+
+  const handlePointerLeave = React.useCallback(
+    (event: React.PointerEvent<React.ComponentRef<typeof CommandPrimitive.Item>>) => {
+      onPointerLeave?.(event);
+
+      if (!event.defaultPrevented) {
+        setPointerItemId?.((currentItemId) => (currentItemId === itemId ? null : currentItemId));
+        setPointerDisabledItemId?.((currentItemId) =>
+          currentItemId === itemId ? null : currentItemId,
+        );
+      }
+    },
+    [itemId, onPointerLeave, setPointerDisabledItemId, setPointerItemId],
+  );
+
+  const isIndicatorActive = indicatorContext?.activeItemId === itemId && !isItemDisabled();
+
   return (
     <CommandPrimitive.Item
-      ref={ref}
+      ref={setItemRef}
       className={cn(
-        "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 before:content-[''] before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-1 before:rounded-r-sm before:bg-foreground before:opacity-0 before:transition-opacity hover:before:opacity-100 data-[selected=true]:before:opacity-100 data-[disabled=true]:before:opacity-0 data-[disabled=true]:data-[selected=true]:before:opacity-0 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:cursor-not-allowed data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
         className,
       )}
+      disabled={disabled}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
       {...props}
-    />
+    >
+      {isIndicatorActive && (
+        <motion.span
+          aria-hidden="true"
+          className="pointer-events-none absolute left-0 top-1.5 bottom-1.5 w-1 rounded-r-sm bg-foreground"
+          data-layout-id={COMMAND_ITEM_INDICATOR_LAYOUT_ID}
+          data-slot="command-item-leading-indicator"
+          layoutId={COMMAND_ITEM_INDICATOR_LAYOUT_ID}
+          transition={getMotionTransition(ANIMATION_DURATIONS.fast, EASING_FUNCTIONS.easeOutCubic)}
+        />
+      )}
+      {props.children}
+    </CommandPrimitive.Item>
   );
 }
 

--- a/src/shared/components/ui/command.tsx
+++ b/src/shared/components/ui/command.tsx
@@ -145,7 +145,7 @@ function CommandItem({ ref, className, ...props }: CommandItemProps) {
     <CommandPrimitive.Item
       ref={ref}
       className={cn(
-        "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
         className,
       )}
       {...props}

--- a/src/shared/lib/animations.test.ts
+++ b/src/shared/lib/animations.test.ts
@@ -7,6 +7,7 @@ import {
   PANEL_ANIMATIONS,
   prefersReducedMotion,
   getTransitionStyle,
+  getMotionSpringTransition,
   getMotionTransition,
   motionVariants,
 } from './animations';
@@ -188,6 +189,49 @@ describe('animations', () => {
     it('respects reduced motion even with default arguments', () => {
       matchMediaSpy.mockReturnValue({ matches: true });
       const result = getMotionTransition();
+      expect(result).toEqual({ duration: 0 });
+    });
+  });
+
+  describe('getMotionSpringTransition', () => {
+    let matchMediaSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      matchMediaSpy = vi.fn();
+      Object.defineProperty(window, 'matchMedia', {
+        value: matchMediaSpy,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('returns a bounce-free spring transition with default duration', () => {
+      matchMediaSpy.mockReturnValue({ matches: false });
+      const result = getMotionSpringTransition();
+      expect(result).toEqual({
+        type: 'spring',
+        duration: ANIMATION_DURATIONS.slow,
+        bounce: 0,
+      });
+    });
+
+    it('returns a bounce-free spring transition with custom duration', () => {
+      matchMediaSpy.mockReturnValue({ matches: false });
+      const result = getMotionSpringTransition(0.2);
+      expect(result).toEqual({
+        type: 'spring',
+        duration: 0.2,
+        bounce: 0,
+      });
+    });
+
+    it('returns zero-duration transition when user prefers reduced motion', () => {
+      matchMediaSpy.mockReturnValue({ matches: true });
+      const result = getMotionSpringTransition();
       expect(result).toEqual({ duration: 0 });
     });
   });

--- a/src/shared/lib/animations.ts
+++ b/src/shared/lib/animations.ts
@@ -76,6 +76,15 @@ export const getMotionTransition = (
   return { duration, ease };
 };
 
+export const getMotionSpringTransition = (
+  duration: number = ANIMATION_DURATIONS.slow,
+): Transition => {
+  if (prefersReducedMotion()) {
+    return { duration: 0 };
+  }
+  return { type: 'spring', duration, bounce: 0 };
+};
+
 /**
  * Common motion animation variants
  */

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -9,6 +9,7 @@ export {
   ANIMATION_DURATIONS,
   EASING_CSS,
   EASING_FUNCTIONS,
+  getMotionSpringTransition,
   getMotionTransition,
   getTransitionStyle,
   motionVariants,


### PR DESCRIPTION
## Summary

- replace the previous hover-only accent background fix with a shared command-item leading indicator
- animate pointer-hover and keyboard/cmdk selection movement between command rows with a shared Motion layout id
- use a bounce-free spring transition for indicator movement so the marker follows hover and arrow-key changes more naturally
- keep the initial indicator placement instant to avoid a page-load style entrance animation
- keep the existing selected-row accent background as a secondary cue for keyboard navigation
- cover pointer hover, cmdk-selected movement, disabled item clearing, disabled-to-enabled recovery, motion-mode behavior, and reduced-motion spring fallback in tests

## Verification

- `pnpm exec vitest run src/shared/components/ui/command.test.tsx src/shared/lib/animations.test.ts`
- `pnpm typecheck`
- `pnpm exec vitest run`
- `pnpm build`
- `git diff --check`

## Notes

This revision intentionally avoids choosing a stronger custom color or changing global theme tokens. The active row now has a structural leading marker. Once the marker is initially placed, both pointer hover and keyboard-driven selection changes move that marker vertically between command items with a bounce-free spring. The shared spring helper still respects `prefers-reduced-motion` by returning a zero-duration transition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a visual leading indicator for active command items in command palettes and action menus, visible during mouse hover and keyboard navigation with improved accessibility for disabled states.

* **Tests**
  * Added comprehensive test coverage for command item behavior and motion spring transitions with reduced-motion support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->