### PR TITLE
ci(landing): bound Playwright browser install time

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -22,11 +22,12 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -58,8 +59,13 @@ jobs:
       - name: Move index.html to artifact root
         run: cp dist-landing/landing/index.html dist-landing/index.html
 
+      - name: Install Playwright system dependencies
+        timeout-minutes: 5
+        run: pnpm exec playwright install-deps chromium-headless-shell
+
       - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 5
+        run: pnpm exec playwright install --only-shell chromium
 
       - name: Prerender landing page for SEO
         run: pnpm prerender:landing


### PR DESCRIPTION
## Summary
- Cancel superseded GitHub Pages deploy runs instead of letting a stale run block the `pages` concurrency group.
- Add a 20-minute build job timeout.
- Split Playwright system dependency installation from browser download, with 5-minute timeouts on each step.
- Install only the Chromium headless shell needed by the prerender script.

## Context
The Deploy Landing Page run from PR #378 stayed in progress at `Install Playwright browsers`:
https://github.com/jaem1n207/synchronize-tab-scrolling/actions/runs/28223285441/job/83609223688

That run has been cancelled so the Pages concurrency group is no longer blocked.

## Validation
- `./node_modules/.bin/prettier --check .github/workflows/deploy-landing.yml`
- `git diff --check`
- `./node_modules/.bin/playwright install --only-shell chromium --dry-run`
- `./node_modules/.bin/playwright install-deps chromium-headless-shell --dry-run`

Note: `actionlint` is not installed in this local environment.
