### PR TITLE
ci(landing): cache Playwright browser installs

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
@@ -39,6 +39,14 @@ jobs:
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
       - name: Update sitemap lastmod and JSON-LD dateModified
         run: |
@@ -64,7 +72,7 @@ jobs:
         run: pnpm exec playwright install-deps chromium-headless-shell
 
       - name: Install Playwright browsers
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: pnpm exec playwright install --only-shell chromium
 
       - name: Prerender landing page for SEO


### PR DESCRIPTION
## Summary
- Add an Actions cache for Playwright browser artifacts.
- Increase the build job timeout from 20 to 30 minutes.
- Increase the browser install step timeout from 5 to 15 minutes.

## Context
PR #380 fixed the unbounded pending state, but the validation run showed the browser install reached 100% download and then timed out during installation/post-processing:
https://github.com/jaem1n207/synchronize-tab-scrolling/actions/runs/28224868355/job/83614316219

This keeps the install bounded while giving Playwright enough time to finish and caching the browser payload for future deploys.

## Validation
- `./node_modules/.bin/prettier --check .github/workflows/deploy-landing.yml`
- `git diff --check`
- `./node_modules/.bin/playwright install --only-shell chromium --dry-run`
