### PR TITLE
ci(landing): use runner Chrome for prerender

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -40,14 +40,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-
       - name: Update sitemap lastmod and JSON-LD dateModified
         run: |
           CONTENT_DATE=$(git log -1 --format=%cd --date=short -- src/landing/ src/shared/)
@@ -67,18 +59,14 @@ jobs:
       - name: Move index.html to artifact root
         run: cp dist-landing/landing/index.html dist-landing/index.html
 
-      - name: Install Playwright system dependencies
-        timeout-minutes: 5
-        run: pnpm exec playwright install-deps chromium-headless-shell
-
-      - name: Install Playwright browsers
-        timeout-minutes: 15
-        run: pnpm exec playwright install --only-shell chromium
+      - name: Verify system Chrome
+        run: google-chrome --version
 
       - name: Prerender landing page for SEO
         run: pnpm prerender:landing
         env:
           LANDING_BASE: /synchronize-tab-scrolling/
+          PLAYWRIGHT_CHROMIUM_CHANNEL: chrome
 
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/scripts/prerender-landing.ts
+++ b/scripts/prerender-landing.ts
@@ -7,6 +7,7 @@ import { chromium, type Browser } from '@playwright/test';
 
 const DIST_DIR = join(process.cwd(), 'dist-landing');
 const LANDING_BASE = process.env.LANDING_BASE ?? '/';
+const CHROMIUM_CHANNEL = process.env.PLAYWRIGHT_CHROMIUM_CHANNEL;
 
 const MIME_TYPES: Record<string, string> = {
   '.html': 'text/html; charset=utf-8',
@@ -65,7 +66,13 @@ async function prerender() {
 
   let browser: Browser | undefined;
   try {
-    browser = await chromium.launch();
+    browser = await chromium.launch(
+      CHROMIUM_CHANNEL
+        ? {
+            channel: CHROMIUM_CHANNEL,
+          }
+        : undefined,
+    );
     const page = await browser.newPage();
 
     page.on('pageerror', (err) => console.error(`[browser] error: ${err.message}`));


### PR DESCRIPTION
## Summary
- Use the GitHub-hosted runner's system Chrome for landing prerender.
- Remove the Playwright browser install/cache steps from the Pages workflow.
- Keep the default local prerender behavior unchanged unless `PLAYWRIGHT_CHROMIUM_CHANNEL` is set.

## Context
The previous fixes bounded the stuck workflow, but the latest run still spent several minutes in Playwright browser installation and timed out after reaching 100% download:
https://github.com/jaem1n207/synchronize-tab-scrolling/actions/runs/28225337599

The ubuntu-24.04 runner image used by the failing job includes Google Chrome and Chromium, so CI can skip Playwright browser artifact installation entirely and launch the system Chrome channel.

## Validation
- `./node_modules/.bin/prettier --check .github/workflows/deploy-landing.yml scripts/prerender-landing.ts`
- `git diff --check`
- `./node_modules/.bin/eslint scripts/prerender-landing.ts`
- `LANDING_BASE=/synchronize-tab-scrolling/ ./node_modules/.bin/vite build --config vite.config.landing.mts`
- `LANDING_BASE=/synchronize-tab-scrolling/ PLAYWRIGHT_CHROMIUM_CHANNEL=chrome ./node_modules/.bin/esno scripts/prerender-landing.ts`

Note: the first local prerender attempt failed only because the sandbox blocked `tsx` IPC pipe creation; the same command passed outside the sandbox.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved landing page deployment reliability by using the system Chrome browser during prerendering.
  * Removed extra browser setup steps from the deployment flow, simplifying and speeding up the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->