### PR TITLE
Add maintainer automation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -82,10 +82,9 @@
   - changed-files:
       - any-glob-to-any-file:
           - 'src/shared/lib/platform*'
-          - 'src/**/browser**'
-          - 'src/**/firefox**'
-          - 'src/**/chrome**'
-          - 'src/**/edge**'
+          - 'src/landing/lib/detect-browser*'
+          - 'src/landing/hooks/use-platform*'
+          - 'scripts/publish-edge.mjs'
 
 'area:release-risk':
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,133 @@
+'area:ci':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+'area:docs':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - 'README.md'
+          - 'README-ko_kr.md'
+          - 'AGENTS.md'
+
+'area:extension':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/background/**'
+          - 'src/contentScripts/**'
+          - 'src/popup/**'
+          - 'src/shared/**'
+          - 'src/manifest.ts'
+          - 'extension/**'
+          - 'vite.config.background.mts'
+          - 'vite.config.content.mts'
+          - 'vite.config.ts'
+
+'area:landing':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/landing/**'
+          - 'vite.config.landing.mts'
+          - 'scripts/prerender-landing.ts'
+          - 'scripts/fetch-store-stats.ts'
+          - 'e2e/landing/**'
+
+'area:i18n':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/**/i18n/**'
+          - 'src/**/translations/**'
+          - 'src/**/locales/**'
+          - 'src/landing/lib/translations/**'
+          - 'scripts/validate-i18n.ts'
+
+'area:e2e':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'e2e/**'
+          - 'playwright.config*.ts'
+
+'area:release':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'release.config.js'
+          - 'scripts/publish-edge.mjs'
+          - 'docs/guides/store-deployment.md'
+          - '.github/workflows/release.yml'
+
+'area:package':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'package.json'
+          - 'pnpm-lock.yaml'
+          - 'pnpm-workspace.yaml'
+          - 'tsconfig.json'
+
+'area:store-stats':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/landing/public/store-stats.json'
+          - 'scripts/fetch-store-stats.ts'
+          - '.github/workflows/update-store-stats.yml'
+
+'area:security':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/**/permissions**'
+          - 'src/**/excluded**'
+          - 'src/manifest.ts'
+
+'area:browser-compat':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/shared/lib/platform*'
+          - 'src/**/browser**'
+          - 'src/**/firefox**'
+          - 'src/**/chrome**'
+          - 'src/**/edge**'
+
+'area:release-risk':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'release.config.js'
+          - '.github/workflows/release.yml'
+          - 'scripts/publish-edge.mjs'
+          - 'package.json'
+          - 'pnpm-lock.yaml'
+          - 'src/manifest.ts'
+
+'area:landing-release-risk':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/landing/**'
+          - 'vite.config.landing.mts'
+          - '.github/workflows/deploy-landing.yml'
+
+'area:design-spec':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/superpowers/specs/**'
+          - 'docs/superpowers/plans/**'
+
+'type:feature':
+  - head-branch:
+      - '^feat[/-]'
+      - '^feature[/-]'
+
+'type:fix':
+  - head-branch:
+      - '^fix[/-]'
+      - '^hotfix[/-]'
+
+'type:docs':
+  - head-branch:
+      - '^docs[/-]'
+
+'type:ci':
+  - head-branch:
+      - '^ci[/-]'
+
+'target:main':
+  - base-branch:
+      - '^main$'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,24 @@
+name: Label PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        with:
+          sync-labels: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Mark Stale Issues
+
+on:
+  schedule:
+    - cron: '23 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    name: Mark stale issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark inactive issues
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        with:
+          stale-issue-label: 'status:stale'
+          days-before-issue-stale: 90
+          days-before-issue-close: -1
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-pr-stale-when-updated: false
+          stale-issue-message: >-
+            This issue has had no activity for 90 days, so it is marked as stale.
+            Comment or remove `status:stale` if it is still relevant.
+          exempt-issue-labels: >-
+            security,pinned,in-progress,needs-decision,store-review,browser-compatibility
+          operations-per-run: 50

--- a/docs/superpowers/plans/2026-06-26-maintainer-automation.md
+++ b/docs/superpowers/plans/2026-06-26-maintainer-automation.md
@@ -203,7 +203,7 @@ Create `/Users/jaemin/programming/projects/active/synchronize-tab-scrolling/.git
   - head-branch:
       - '^ci[/-]'
 
-'status:needs-review':
+'target:main':
   - base-branch:
       - '^main$'
 ```

--- a/docs/superpowers/plans/2026-06-26-maintainer-automation.md
+++ b/docs/superpowers/plans/2026-06-26-maintainer-automation.md
@@ -53,6 +53,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
@@ -66,7 +67,7 @@ jobs:
           sync-labels: true
 ```
 
-Expected: The workflow never checks out code and cannot execute pull request changes.
+Expected: The workflow never checks out code and cannot execute pull request changes. `issues: write` allows `actions/labeler` to create missing configured labels on first run.
 
 - [ ] **Step 2: Add the labeler config**
 

--- a/docs/superpowers/plans/2026-06-26-maintainer-automation.md
+++ b/docs/superpowers/plans/2026-06-26-maintainer-automation.md
@@ -1,0 +1,330 @@
+# Maintainer Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add PR label automation and conservative issue stale marking for `synchronize-tab-scrolling` without touching release, landing deploy, store stats, or semantic-release behavior.
+
+**Architecture:** Add one label-only `pull_request_target` workflow, one `.github/labeler.yml`, and one scheduled stale workflow. Existing release/deploy workflows and `release.config.js` remain untouched because extension store release automation already uses secrets and semantic-release.
+
+**Tech Stack:** GitHub Actions, actions/labeler pinned to `v6.1.0`, actions/stale pinned to `v10.3.0`, existing pnpm extension/landing workflows.
+
+---
+
+## File Structure
+
+Create or modify these files inside `/Users/jaemin/programming/projects/active/synchronize-tab-scrolling`.
+
+- Create: `.github/workflows/labeler.yml`
+  - Responsibility: Apply PR labels without checking out or executing PR code.
+- Create: `.github/labeler.yml`
+  - Responsibility: Define file and branch matching rules for extension, landing, i18n, release-risk, docs, e2e, and CI labels.
+- Create: `.github/workflows/stale.yml`
+  - Responsibility: Mark inactive issues stale without closing issues or PRs automatically.
+- Preserve: `.github/workflows/release.yml`
+  - Responsibility: Existing semantic-release and store publishing flow; do not modify.
+- Preserve: `.github/workflows/deploy-landing.yml`
+  - Responsibility: Existing landing deployment; do not modify.
+- Preserve: `.github/workflows/update-store-stats.yml`
+  - Responsibility: Existing weekly store stats automation; do not modify.
+- Preserve: `release.config.js`
+  - Responsibility: Existing semantic-release configuration; do not modify.
+
+## Task 1: Add PR Labeler
+
+**Files:**
+
+- Create: `/Users/jaemin/programming/projects/active/synchronize-tab-scrolling/.github/workflows/labeler.yml`
+- Create: `/Users/jaemin/programming/projects/active/synchronize-tab-scrolling/.github/labeler.yml`
+
+- [ ] **Step 1: Add the labeler workflow**
+
+Create `/Users/jaemin/programming/projects/active/synchronize-tab-scrolling/.github/workflows/labeler.yml`:
+
+```yaml
+name: Label PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        with:
+          sync-labels: true
+```
+
+Expected: The workflow never checks out code and cannot execute pull request changes.
+
+- [ ] **Step 2: Add the labeler config**
+
+Create `/Users/jaemin/programming/projects/active/synchronize-tab-scrolling/.github/labeler.yml`:
+
+```yaml
+'area:ci':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+'area:docs':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - 'README.md'
+          - 'README-ko_kr.md'
+          - 'AGENTS.md'
+
+'area:extension':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/background/**'
+          - 'src/contentScripts/**'
+          - 'src/popup/**'
+          - 'src/shared/**'
+          - 'src/manifest.ts'
+          - 'extension/**'
+          - 'vite.config.background.mts'
+          - 'vite.config.content.mts'
+          - 'vite.config.ts'
+
+'area:landing':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/landing/**'
+          - 'vite.config.landing.mts'
+          - 'scripts/prerender-landing.ts'
+          - 'scripts/fetch-store-stats.ts'
+          - 'e2e/landing/**'
+
+'area:i18n':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/**/i18n/**'
+          - 'src/**/translations/**'
+          - 'src/**/locales/**'
+          - 'src/landing/lib/translations/**'
+          - 'scripts/validate-i18n.ts'
+
+'area:e2e':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'e2e/**'
+          - 'playwright.config*.ts'
+
+'area:release':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'release.config.js'
+          - 'scripts/publish-edge.mjs'
+          - 'docs/guides/store-deployment.md'
+          - '.github/workflows/release.yml'
+
+'area:package':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'package.json'
+          - 'pnpm-lock.yaml'
+          - 'pnpm-workspace.yaml'
+          - 'tsconfig.json'
+
+'area:store-stats':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/landing/public/store-stats.json'
+          - 'scripts/fetch-store-stats.ts'
+          - '.github/workflows/update-store-stats.yml'
+
+'area:security':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/**/permissions**'
+          - 'src/**/excluded**'
+          - 'src/manifest.ts'
+
+'area:browser-compat':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/shared/lib/platform*'
+          - 'src/**/browser**'
+          - 'src/**/firefox**'
+          - 'src/**/chrome**'
+          - 'src/**/edge**'
+
+'area:release-risk':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'release.config.js'
+          - '.github/workflows/release.yml'
+          - 'scripts/publish-edge.mjs'
+          - 'package.json'
+          - 'pnpm-lock.yaml'
+          - 'src/manifest.ts'
+
+'area:landing-release-risk':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/landing/**'
+          - 'vite.config.landing.mts'
+          - '.github/workflows/deploy-landing.yml'
+
+'area:design-spec':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/superpowers/specs/**'
+          - 'docs/superpowers/plans/**'
+
+'type:feature':
+  - head-branch:
+      - '^feat[/-]'
+      - '^feature[/-]'
+
+'type:fix':
+  - head-branch:
+      - '^fix[/-]'
+      - '^hotfix[/-]'
+
+'type:docs':
+  - head-branch:
+      - '^docs[/-]'
+
+'type:ci':
+  - head-branch:
+      - '^ci[/-]'
+
+'status:needs-review':
+  - base-branch:
+      - '^main$'
+```
+
+Expected: The config distinguishes extension runtime changes from landing, release-risk, browser compatibility, i18n, docs, and CI changes.
+
+- [ ] **Step 3: Validate labeler files**
+
+Run:
+
+```bash
+actionlint .github/workflows/labeler.yml
+ruby -e 'require "yaml"; YAML.load_file(".github/labeler.yml"); puts "labeler config ok"'
+```
+
+Expected: `actionlint` prints no output, and Ruby prints `labeler config ok`.
+
+- [ ] **Step 4: Confirm sensitive workflows are unchanged**
+
+Run:
+
+```bash
+git diff -- .github/workflows/release.yml .github/workflows/deploy-landing.yml .github/workflows/update-store-stats.yml release.config.js
+```
+
+Expected: No output.
+
+- [ ] **Step 5: Commit labeler automation**
+
+Run:
+
+```bash
+git add .github/workflows/labeler.yml .github/labeler.yml docs/superpowers/plans/2026-06-26-maintainer-automation.md
+git commit -m "ci: add pull request labeler"
+```
+
+Expected: One commit contains labeler files and this plan file; release/deploy files remain untouched.
+
+## Task 2: Add Conservative Issue Stale Marking
+
+**Files:**
+
+- Create: `/Users/jaemin/programming/projects/active/synchronize-tab-scrolling/.github/workflows/stale.yml`
+
+- [ ] **Step 1: Add the stale workflow**
+
+Create `/Users/jaemin/programming/projects/active/synchronize-tab-scrolling/.github/workflows/stale.yml`:
+
+```yaml
+name: Mark Stale Issues
+
+on:
+  schedule:
+    - cron: '23 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Mark stale issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark inactive issues
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        with:
+          stale-issue-label: 'status:stale'
+          stale-pr-label: 'status:stale'
+          days-before-issue-stale: 90
+          days-before-issue-close: -1
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-message: >-
+            This issue has had no activity for 90 days, so it is marked as stale.
+            Comment or remove `status:stale` if it is still relevant.
+          exempt-issue-labels: >-
+            security,pinned,in-progress,needs-decision,store-review,browser-compatibility
+          exempt-pr-labels: >-
+            security,pinned,in-progress,needs-decision,store-review,browser-compatibility
+          operations-per-run: 50
+```
+
+Expected: The workflow marks inactive issues stale after 90 days, never closes issues, and never marks or closes PRs automatically.
+
+- [ ] **Step 2: Validate stale workflow syntax**
+
+Run:
+
+```bash
+actionlint .github/workflows/stale.yml
+```
+
+Expected: No output and exit code `0`.
+
+- [ ] **Step 3: Confirm semantic-release files are unchanged**
+
+Run:
+
+```bash
+git diff -- .github/workflows/release.yml release.config.js CHANGELOG.md package.json
+```
+
+Expected: No output.
+
+- [ ] **Step 4: Commit stale automation**
+
+Run:
+
+```bash
+git add .github/workflows/stale.yml
+git commit -m "ci: add stale issue marking"
+```
+
+Expected: One commit contains only the stale workflow.
+
+## Self-Review Checklist
+
+- [ ] Release, landing deploy, store stats, and semantic-release files remain unchanged.
+- [ ] Labeler uses `pull_request_target` without checkout or code execution.
+- [ ] Stale marks issues only and never auto-closes issues or PRs.
+- [ ] Release Drafter and PR checklist comments are not included in this first implementation.
+- [ ] All third-party actions are pinned to full commit SHA.

--- a/docs/superpowers/plans/2026-06-26-maintainer-automation.md
+++ b/docs/superpowers/plans/2026-06-26-maintainer-automation.md
@@ -285,7 +285,7 @@ jobs:
           operations-per-run: 50
 ```
 
-Expected: The workflow marks inactive issues stale after 90 days, never closes issues, and never marks, closes, or removes stale labels from PRs.
+Expected: The workflow marks inactive issues stale after 90 days, never closes issues, and never marks, closes, or removes stale labels from PRs. The remote `status:stale` label must exist before this workflow runs because `actions/stale` does not create missing labels.
 
 - [ ] **Step 2: Validate stale workflow syntax**
 
@@ -323,5 +323,6 @@ Expected: One commit contains only the stale workflow.
 - [ ] Release, landing deploy, store stats, and semantic-release files remain unchanged.
 - [ ] Labeler uses `pull_request_target` without checkout or code execution.
 - [ ] Stale marks issues only and never auto-closes issues or mutates PRs.
+- [ ] The remote `status:stale` label exists before the stale workflow is enabled.
 - [ ] Release Drafter and PR checklist comments are not included in this first implementation.
 - [ ] All third-party actions are pinned to full commit SHA.

--- a/docs/superpowers/plans/2026-06-26-maintainer-automation.md
+++ b/docs/superpowers/plans/2026-06-26-maintainer-automation.md
@@ -158,10 +158,9 @@ Create `/Users/jaemin/programming/projects/active/synchronize-tab-scrolling/.git
   - changed-files:
       - any-glob-to-any-file:
           - 'src/shared/lib/platform*'
-          - 'src/**/browser**'
-          - 'src/**/firefox**'
-          - 'src/**/chrome**'
-          - 'src/**/edge**'
+          - 'src/landing/lib/detect-browser*'
+          - 'src/landing/hooks/use-platform*'
+          - 'scripts/publish-edge.mjs'
 
 'area:release-risk':
   - changed-files:

--- a/docs/superpowers/plans/2026-06-26-maintainer-automation.md
+++ b/docs/superpowers/plans/2026-06-26-maintainer-automation.md
@@ -19,7 +19,7 @@ Create or modify these files inside `/Users/jaemin/programming/projects/active/s
 - Create: `.github/labeler.yml`
   - Responsibility: Define file and branch matching rules for extension, landing, i18n, release-risk, docs, e2e, and CI labels.
 - Create: `.github/workflows/stale.yml`
-  - Responsibility: Mark inactive issues stale without closing issues or PRs automatically.
+  - Responsibility: Mark inactive issues stale without closing issues or mutating PRs automatically.
 - Preserve: `.github/workflows/release.yml`
   - Responsibility: Existing semantic-release and store publishing flow; do not modify.
 - Preserve: `.github/workflows/deploy-landing.yml`
@@ -263,7 +263,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   stale:
@@ -274,22 +273,20 @@ jobs:
         uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           stale-issue-label: 'status:stale'
-          stale-pr-label: 'status:stale'
           days-before-issue-stale: 90
           days-before-issue-close: -1
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          remove-pr-stale-when-updated: false
           stale-issue-message: >-
             This issue has had no activity for 90 days, so it is marked as stale.
             Comment or remove `status:stale` if it is still relevant.
           exempt-issue-labels: >-
             security,pinned,in-progress,needs-decision,store-review,browser-compatibility
-          exempt-pr-labels: >-
-            security,pinned,in-progress,needs-decision,store-review,browser-compatibility
           operations-per-run: 50
 ```
 
-Expected: The workflow marks inactive issues stale after 90 days, never closes issues, and never marks or closes PRs automatically.
+Expected: The workflow marks inactive issues stale after 90 days, never closes issues, and never marks, closes, or removes stale labels from PRs.
 
 - [ ] **Step 2: Validate stale workflow syntax**
 
@@ -326,6 +323,6 @@ Expected: One commit contains only the stale workflow.
 
 - [ ] Release, landing deploy, store stats, and semantic-release files remain unchanged.
 - [ ] Labeler uses `pull_request_target` without checkout or code execution.
-- [ ] Stale marks issues only and never auto-closes issues or PRs.
+- [ ] Stale marks issues only and never auto-closes issues or mutates PRs.
 - [ ] Release Drafter and PR checklist comments are not included in this first implementation.
 - [ ] All third-party actions are pinned to full commit SHA.

--- a/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
+++ b/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
@@ -47,7 +47,7 @@ The latest tags below were verified from live GitHub tag refs on 2026-06-26 KST.
 
 ## Error Handling
 
-- Labeler failures caused by fork permissions should be handled by the label-only `pull_request_target` design, not by widening token permissions beyond `pull-requests: write` and `contents: read`.
+- Labeler failures caused by fork permissions should be handled by the label-only `pull_request_target` design with no checkout or shell execution. Include `issues: write` only so `actions/labeler` can create missing configured labels on first run.
 - Stale automation must exempt `security`, `pinned`, `in-progress`, `needs-decision`, and release-critical work.
 - Comment automation must update an existing bot comment by marker; duplicate comments are considered a design failure.
 - If a workflow begins producing noisy labels or stale events, the rollback is to disable the single new workflow file rather than touching build or release jobs.

--- a/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
+++ b/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
@@ -1,0 +1,94 @@
+# Maintainer Automation Design
+
+Date: 2026-06-26
+
+## Shared Baseline
+
+This project is part of a four-repository maintainer automation rollout covering:
+
+- `synchronize-tab-scrolling`
+- `truck-harvester`
+- `eslint-config`
+- `bendd`
+
+The rollout uses a common maintainer baseline with repository-specific exceptions. The baseline automates repetitive triage without replacing the repository's existing release, build, or deployment contract.
+
+Common rules:
+
+- Use a consistent label taxonomy: `area:*`, `type:*`, `scope:*`, and `status:*`.
+- Add `actions/labeler` for PR triage based on file paths and branch names.
+- Run label/comment workflows with `pull_request_target` only when they do not checkout or execute untrusted PR code.
+- Apply stale handling conservatively, starting with issues and avoiding automatic PR closure unless explicitly enabled later.
+- Use `peter-evans/create-or-update-comment` only when a stable marker prevents duplicate bot comments.
+- Prefer repository-native validation scripts over broad Super-Linter defaults.
+- Preserve existing release/deploy workflows unless the repository-specific section explicitly says otherwise.
+
+## Latest Action Versions
+
+The latest tags below were verified from live GitHub tag refs on 2026-06-26 KST. Implementation should use these versions or newer if re-verified, and should pin third-party actions to the full tag SHA rather than floating version tags.
+
+| Action                                 | Latest tag verified on 2026-06-26 KST | Tag SHA to pin during implementation       |
+| -------------------------------------- | ------------------------------------- | ------------------------------------------ |
+| `actions/labeler`                      | `v6.1.0`                              | `f27b608878404679385c85cfa523b85ccb86e213` |
+| `actions/stale`                        | `v10.3.0`                             | `eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899` |
+| `release-drafter/release-drafter`      | `v7.5.1`                              | `3832cfb52f98ab0f0e5b62aecf94909e334d4da6` |
+| `peter-evans/create-or-update-comment` | `v5.0.0`                              | `e8674b075228eee787fea43ef493e45ece1004c9` |
+| `actions/checkout`                     | `v7.0.0`                              | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` |
+| `actions/setup-node`                   | `v6.4.0`                              | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` |
+| `pnpm/action-setup`                    | `v6.0.9`                              | `008330803749db0355799c700092d9a85fd074e9` |
+| `oven-sh/setup-bun`                    | `v2.2.0`                              | `0c5077e51419868618aeaa5fe8019c62421857d6` |
+
+## Security Requirements
+
+- Every workflow must declare minimal `permissions`.
+- `pull_request_target` workflows may label or comment, but must not checkout, build, test, or run code from the pull request branch.
+- Third-party actions must be pinned to full commit SHA in the implementation plan.
+- Secret-bearing release or deploy workflows are out of scope unless the repository already has them and this design explicitly preserves them.
+
+## Error Handling
+
+- Labeler failures caused by fork permissions should be handled by the label-only `pull_request_target` design, not by widening token permissions beyond `pull-requests: write` and `contents: read`.
+- Stale automation must exempt `security`, `pinned`, `in-progress`, `needs-decision`, and release-critical work.
+- Comment automation must update an existing bot comment by marker; duplicate comments are considered a design failure.
+- If a workflow begins producing noisy labels or stale events, the rollback is to disable the single new workflow file rather than touching build or release jobs.
+
+## Repository Context
+
+`synchronize-tab-scrolling` is an actively shipped browser extension with Chrome, Edge, and Firefox distribution. It already has release, landing deploy, and store stats workflows. Release is handled by `semantic-release`, which writes changelog/release assets and publishes store packages. Landing commits use the `(landing)` scope to avoid triggering extension store releases.
+
+Because release automation is already sensitive and secret-bearing, this rollout must avoid changing release/deploy behavior.
+
+## Proposed Automation
+
+Add Labeler:
+
+- `area:extension` for extension runtime, popup, background, content scripts, manifest, and shared extension logic.
+- `area:landing` for `src/landing/**`, `vite.config.landing.mts`, landing e2e tests, and landing docs.
+- `area:i18n` for extension or landing translation files.
+- `area:e2e` for Playwright tests.
+- `area:release` for `release.config.js`, packaging scripts, and store deployment docs.
+- `area:ci` for `.github/**`.
+- `area:docs` for `docs/**` and README changes.
+
+Add conservative Stale:
+
+- Issue-only stale behavior with exemptions for `security`, `pinned`, `in-progress`, `needs-decision`, `store-review`, and browser compatibility issues.
+- Do not auto-close PRs.
+
+Optional PR checklist comment:
+
+- Use `peter-evans/create-or-update-comment@v5.0.0`, pinned to `e8674b075228eee787fea43ef493e45ece1004c9` during implementation, only for PRs that touch release, store, or landing deployment paths.
+- Comment should remind maintainers which manual checks are relevant, such as landing-only scope safety, store release risk, or browser-specific verification.
+
+## Explicit Non-Goals
+
+- Do not add Release Drafter. `semantic-release` is already the source of truth for changelog and GitHub releases.
+- Do not modify `release.yml`, `deploy-landing.yml`, `update-store-stats.yml`, or `release.config.js` in this phase.
+- Do not add Super-Linter; existing extension and landing checks are more specific.
+
+## Testing Plan
+
+- Validate Labeler and Stale YAML/config files without triggering release workflows.
+- Confirm added workflows do not request secret access.
+- Confirm `pull_request_target` workflows do not checkout or execute PR code.
+- Confirm landing path labels do not interfere with the existing `(landing)` commit-scope release guard.

--- a/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
+++ b/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
@@ -18,7 +18,7 @@ Common rules:
 - Use a consistent label taxonomy: `area:*`, `type:*`, `scope:*`, and `status:*`.
 - Add `actions/labeler` for PR triage based on file paths and branch names.
 - Run label/comment workflows with `pull_request_target` only when they do not checkout or execute untrusted PR code.
-- Apply stale handling conservatively, starting with issues and avoiding automatic PR closure unless explicitly enabled later.
+- Apply stale handling conservatively, starting with issues and avoiding PR mutation unless explicitly enabled later.
 - Use `peter-evans/create-or-update-comment` only when a stable marker prevents duplicate bot comments.
 - Prefer repository-native validation scripts over broad Super-Linter defaults.
 - Preserve existing release/deploy workflows unless the repository-specific section explicitly says otherwise.
@@ -73,7 +73,7 @@ Add Labeler:
 Add conservative Stale:
 
 - Issue-only stale behavior with exemptions for `security`, `pinned`, `in-progress`, `needs-decision`, `store-review`, and browser compatibility issues.
-- Do not auto-close PRs.
+- Do not mutate or auto-close PRs.
 
 Optional PR checklist comment:
 

--- a/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
+++ b/docs/superpowers/specs/2026-06-26-maintainer-automation-design.md
@@ -73,6 +73,7 @@ Add Labeler:
 Add conservative Stale:
 
 - Issue-only stale behavior with exemptions for `security`, `pinned`, `in-progress`, `needs-decision`, `store-review`, and browser compatibility issues.
+- Ensure the remote `status:stale` label exists because `actions/stale` does not create missing labels.
 - Do not mutate or auto-close PRs.
 
 Optional PR checklist comment:


### PR DESCRIPTION
## Summary
- Add a pull_request_target labeler workflow with pinned actions and constrained permissions.
- Add path-based labels for extension, landing, browser compatibility, release, tests, docs, and dependency changes.
- Add stale issue marking for inactive issues without mutating pull requests or closing issues automatically.

## Test Plan
- ruby YAML parse for .github/workflows/labeler.yml, .github/labeler.yml, .github/workflows/stale.yml
- forbidden-pattern scan for checkout/run/secrets in labeler workflow
- forbidden-pattern scan for PR mutation and write-expanded permissions in stale workflow
- verified remote label status:stale exists