### PR TITLE
ci: add extension PR checks gate

### DIFF
--- a/.github/workflows/extension-pr-checks.yml
+++ b/.github/workflows/extension-pr-checks.yml
@@ -1,0 +1,134 @@
+name: Extension PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  extension-pr-checks:
+    name: extension-pr-checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect extension-impacting changes
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD)"
+
+          echo "Changed files:"
+          if [ -n "$changed_files" ]; then
+            echo "$changed_files" | sed 's/^/- /'
+          else
+            echo "- none"
+          fi
+
+          extension_changed=false
+
+          while IFS= read -r file; do
+            case "$file" in
+              .github/workflows/extension-pr-checks.yml | \
+              e2e/** | \
+              extension/_locales/** | \
+              package.json | \
+              pnpm-lock.yaml | \
+              playwright.config*.ts | \
+              scripts/** | \
+              src/background/** | \
+              src/contentScripts/** | \
+              src/manifest.ts | \
+              src/popup/** | \
+              src/shared/** | \
+              tsconfig*.json | \
+              uno.config.ts | \
+              vite.config*)
+                extension_changed=true
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          echo "extension_changed=$extension_changed" >> "$GITHUB_OUTPUT"
+
+      - name: No extension-impacting changes
+        if: steps.changes.outputs.extension_changed != 'true'
+        run: echo "No extension-impacting changes detected."
+
+      - uses: pnpm/action-setup@v5
+        if: steps.changes.outputs.extension_changed == 'true'
+
+      - uses: actions/setup-node@v6
+        if: steps.changes.outputs.extension_changed == 'true'
+        with:
+          node-version: 'lts/*'
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Test privacy-safe logging validator
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm privacy:logging:test
+
+      - name: Validate privacy-safe logging
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm privacy:logging
+
+      - name: Validate i18n
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm i18n:validate
+
+      - name: Typecheck
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm typecheck
+
+      - name: Lint
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm lint:check
+
+      - name: Unit tests
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm test -- --run
+
+      - name: Build Chromium extension
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm build
+
+      - name: Preserve Chromium extension build for E2E
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: |
+          rm -rf test-results/chromium-extension
+          mkdir -p test-results/chromium-extension
+          cp -R extension/. test-results/chromium-extension/
+
+      - name: Build Firefox extension
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm build-firefox
+
+      - name: Install Playwright Chromium
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: URL Sync extension smoke tests
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm test:e2e:extension
+        env:
+          EXTENSION_E2E_DIR: test-results/chromium-extension
+
+      - name: Upload extension Playwright report
+        if: failure() && steps.changes.outputs.extension_changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-playwright-report
+          path: playwright-report-extension/
+          retention-days: 7

--- a/.github/workflows/extension-pr-checks.yml
+++ b/.github/workflows/extension-pr-checks.yml
@@ -107,9 +107,9 @@ jobs:
       - name: Preserve Chromium extension build for E2E
         if: steps.changes.outputs.extension_changed == 'true'
         run: |
-          rm -rf test-results/chromium-extension
-          mkdir -p test-results/chromium-extension
-          cp -R extension/. test-results/chromium-extension/
+          rm -rf .extension-e2e/chromium-extension
+          mkdir -p .extension-e2e/chromium-extension
+          cp -R extension/. .extension-e2e/chromium-extension/
 
       - name: Build Firefox extension
         if: steps.changes.outputs.extension_changed == 'true'
@@ -123,7 +123,7 @@ jobs:
         if: steps.changes.outputs.extension_changed == 'true'
         run: pnpm test:e2e:extension
         env:
-          EXTENSION_E2E_DIR: test-results/chromium-extension
+          EXTENSION_E2E_DIR: .extension-e2e/chromium-extension
 
       - name: Upload extension Playwright report
         if: failure() && steps.changes.outputs.extension_changed == 'true'

--- a/.github/workflows/extension-pr-checks.yml
+++ b/.github/workflows/extension-pr-checks.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect extension-impacting changes
         id: changes

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ vite.config.*.timestamp-*
 !.env.example
 
 # Test artifacts
+.extension-e2e/
 playwright-report-extension/
 test-results/
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ vite.config.*.timestamp-*
 !.env.example
 
 # Test artifacts
+playwright-report-extension/
 test-results/
 
 # MCP configuration with sensitive tokens

--- a/docs/superpowers/plans/2026-06-28-extension-pr-checks.md
+++ b/docs/superpowers/plans/2026-06-28-extension-pr-checks.md
@@ -1,0 +1,1286 @@
+# Extension PR Checks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a required `extension-pr-checks` pull request gate that statically blocks privacy-sensitive logging, runs extension health checks, and smoke-tests URL Sync modes in a real Chromium extension context.
+
+**Architecture:** Build the gate in three layers: a TypeScript AST privacy logging validator, a focused Playwright extension smoke suite, and a read-only GitHub Actions workflow that always reports the required `extension-pr-checks` check. The workflow computes extension-impacting file changes inside the job, so landing-only PRs pass quickly without leaving required checks pending.
+
+**Tech Stack:** GitHub Actions, pnpm, TypeScript compiler API, Vitest, Playwright Chromium persistent context, Chrome MV3 service worker extension testing.
+
+---
+
+## References
+
+- Design spec: `docs/superpowers/specs/2026-06-28-extension-pr-checks-design.md`
+- Playwright Chrome extension guide: https://playwright.dev/docs/chrome-extensions
+- Existing landing Playwright config: `playwright.config.landing.ts`
+- Existing extension popup URL Sync UI: `src/shared/components/url-sync-settings.tsx`
+- Existing URL Sync runtime behavior: `src/contentScripts/scroll-sync.ts`
+
+## File Map
+
+### Create
+
+- `.github/workflows/extension-pr-checks.yml`
+  - Required pull request workflow. Job id and display name must stay `extension-pr-checks`.
+- `scripts/privacy-logging-rules.ts`
+  - Pure TypeScript AST analysis for unsafe `logger.info/debug/warn/error` calls.
+- `scripts/privacy-logging-rules.test.ts`
+  - Vitest tests for the AST rules.
+- `scripts/validate-privacy-logging.ts`
+  - CLI wrapper that scans `src/**` and exits non-zero on unsafe logging.
+- `playwright.config.extension.ts`
+  - Isolated Playwright config for extension smoke tests.
+- `e2e/extension/fixtures.ts`
+  - Playwright fixtures for loading the built extension and running local fixture servers.
+- `e2e/extension/url-sync-modes.spec.ts`
+  - Required smoke tests for URL Sync mode behavior and visible mode state.
+
+### Modify
+
+- `package.json`
+  - Add `lint:check`, `privacy:logging`, `privacy:logging:test`, and `test:e2e:extension`.
+- Current source files reported by `pnpm privacy:logging`
+  - Remove raw `url`, `payload`, `data`, `response`, `tab`, `syncState`, `normalizedUrl`, title, and full browser object logging.
+  - Keep safe metadata such as ids, counts, booleans, modes, reasons, and sanitized domains.
+
+### Do Not Modify
+
+- `.github/workflows/release.yml`
+- `.github/workflows/deploy-landing.yml`
+- `.github/workflows/update-store-stats.yml`
+- GitHub repository ruleset or branch protection settings
+
+## Task 1: Privacy Logging Rule Tests And Package Scripts
+
+**Files:**
+
+- Create: `scripts/privacy-logging-rules.test.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Add package scripts for the privacy guard**
+
+Add these scripts to `package.json` under the existing tools or test section:
+
+```json
+{
+  "privacy:logging": "esno scripts/validate-privacy-logging.ts",
+  "privacy:logging:test": "vitest run --root . scripts/privacy-logging-rules.test.ts"
+}
+```
+
+- [ ] **Step 2: Write failing tests for unsafe logger metadata**
+
+Create `scripts/privacy-logging-rules.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+
+import { analyzePrivacyLoggingSource } from './privacy-logging-rules';
+
+function messagesFor(sourceText: string): Array<string> {
+  return analyzePrivacyLoggingSource('src/example.ts', sourceText).map(
+    (violation) => violation.message,
+  );
+}
+
+describe('privacy logging rules', () => {
+  it('allows ids, modes, reasons, booleans, counts, and sanitized domains', () => {
+    expect(
+      messagesFor(`
+        logger.info('Relaying URL sync mode change', {
+          sourceTabId,
+          targetTabId,
+          mode,
+          reason: 'user-change',
+          enabled: true,
+          tabCount: 2,
+          domain: 'example.com',
+        });
+      `),
+    ).toEqual([]);
+  });
+
+  it('rejects raw URL metadata keys', () => {
+    expect(
+      messagesFor(`
+        logger.info('URL changed', { url: window.location.href });
+        logger.debug('Relaying URL sync message', { sourceUrl, targetUrl, normalizedUrl });
+      `),
+    ).toEqual([
+      'Do not log "url". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "sourceUrl". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "targetUrl". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "normalizedUrl". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+
+  it('rejects shorthand payload-like metadata', () => {
+    expect(
+      messagesFor(`
+        logger.debug('Received message', { payload });
+        logger.debug('Relaying scroll sync message', { data, sender });
+        logger.error('Invalid acknowledgment', { response });
+      `),
+    ).toEqual([
+      'Do not log "payload". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "data". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "sender". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "response". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+
+  it('rejects direct browser URL and title expressions', () => {
+    expect(
+      messagesFor(`
+        logger.info('Processing tab', { tabId: tab.id, currentUrl: tab.url });
+        logger.info('Page metadata', { pageTitle: document.title });
+      `),
+    ).toEqual([
+      'Do not log "currentUrl". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "pageTitle". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 3: Run the failing privacy rule tests**
+
+Run:
+
+```bash
+pnpm privacy:logging:test
+```
+
+Expected: FAIL because `scripts/privacy-logging-rules.ts` does not exist.
+
+## Task 2: Privacy Logging Rule Implementation
+
+**Files:**
+
+- Create: `scripts/privacy-logging-rules.ts`
+- Test: `scripts/privacy-logging-rules.test.ts`
+
+- [ ] **Step 1: Implement the AST rule module**
+
+Create `scripts/privacy-logging-rules.ts`:
+
+```typescript
+import ts from 'typescript';
+
+export interface PrivacyLoggingViolation {
+  filePath: string;
+  line: number;
+  column: number;
+  message: string;
+}
+
+const LOGGER_METHODS = new Set(['debug', 'error', 'info', 'warn']);
+
+const BANNED_METADATA_NAMES = new Set([
+  'alternateUrl',
+  'alternateUrls',
+  'canonicalUrl',
+  'currentUrl',
+  'data',
+  'documentTitle',
+  'href',
+  'metadata',
+  'normalizedUrl',
+  'pageTitle',
+  'payload',
+  'response',
+  'sender',
+  'sourceUrl',
+  'syncState',
+  'tab',
+  'tabTitle',
+  'targetUrl',
+  'title',
+  'url',
+]);
+
+const BANNED_PROPERTY_ACCESS = new Set([
+  'document.title',
+  'location.href',
+  'payload.url',
+  'tab.title',
+  'tab.url',
+  'window.location.href',
+]);
+
+function isLoggerCall(node: ts.CallExpression): boolean {
+  if (!ts.isPropertyAccessExpression(node.expression)) {
+    return false;
+  }
+
+  const methodName = node.expression.name.text;
+  if (!LOGGER_METHODS.has(methodName)) {
+    return false;
+  }
+
+  const receiver = node.expression.expression;
+  return ts.isIdentifier(receiver) && receiver.text === 'logger';
+}
+
+function getPropertyNameText(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+
+  return null;
+}
+
+function isBannedMetadataName(name: string): boolean {
+  return BANNED_METADATA_NAMES.has(name);
+}
+
+function getExpressionText(sourceFile: ts.SourceFile, node: ts.Node): string {
+  return node.getText(sourceFile).replace(/\s+/g, '');
+}
+
+function expressionContainsUnsafeBrowserData(sourceFile: ts.SourceFile, node: ts.Node): boolean {
+  const text = getExpressionText(sourceFile, node);
+  if (BANNED_PROPERTY_ACCESS.has(text)) {
+    return true;
+  }
+
+  let unsafe = false;
+
+  function visit(current: ts.Node) {
+    if (unsafe) {
+      return;
+    }
+
+    if (ts.isPropertyAccessExpression(current)) {
+      const propertyText = getExpressionText(sourceFile, current);
+      const propertyName = current.name.text;
+      if (BANNED_PROPERTY_ACCESS.has(propertyText) || isBannedMetadataName(propertyName)) {
+        unsafe = true;
+        return;
+      }
+    }
+
+    ts.forEachChild(current, visit);
+  }
+
+  visit(node);
+  return unsafe;
+}
+
+function createViolation(
+  sourceFile: ts.SourceFile,
+  filePath: string,
+  node: ts.Node,
+  metadataName: string,
+): PrivacyLoggingViolation {
+  const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+
+  return {
+    filePath,
+    line: position.line + 1,
+    column: position.character + 1,
+    message: `Do not log "${metadataName}". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.`,
+  };
+}
+
+function analyzeObjectLiteralArgument(
+  sourceFile: ts.SourceFile,
+  filePath: string,
+  argument: ts.ObjectLiteralExpression,
+): Array<PrivacyLoggingViolation> {
+  const violations: Array<PrivacyLoggingViolation> = [];
+
+  for (const property of argument.properties) {
+    if (ts.isShorthandPropertyAssignment(property)) {
+      const name = property.name.text;
+      if (isBannedMetadataName(name)) {
+        violations.push(createViolation(sourceFile, filePath, property.name, name));
+      }
+      continue;
+    }
+
+    if (!ts.isPropertyAssignment(property)) {
+      continue;
+    }
+
+    const name = getPropertyNameText(property.name);
+    if (!name) {
+      continue;
+    }
+
+    if (
+      isBannedMetadataName(name) ||
+      expressionContainsUnsafeBrowserData(sourceFile, property.initializer)
+    ) {
+      violations.push(createViolation(sourceFile, filePath, property.name, name));
+    }
+  }
+
+  return violations;
+}
+
+function analyzeLoggerArgument(
+  sourceFile: ts.SourceFile,
+  filePath: string,
+  argument: ts.Expression,
+): Array<PrivacyLoggingViolation> {
+  if (ts.isObjectLiteralExpression(argument)) {
+    return analyzeObjectLiteralArgument(sourceFile, filePath, argument);
+  }
+
+  if (ts.isIdentifier(argument) && isBannedMetadataName(argument.text)) {
+    return [createViolation(sourceFile, filePath, argument, argument.text)];
+  }
+
+  if (expressionContainsUnsafeBrowserData(sourceFile, argument)) {
+    return [createViolation(sourceFile, filePath, argument, argument.getText(sourceFile))];
+  }
+
+  return [];
+}
+
+export function analyzePrivacyLoggingSource(
+  filePath: string,
+  sourceText: string,
+): Array<PrivacyLoggingViolation> {
+  const scriptKind = filePath.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind,
+  );
+  const violations: Array<PrivacyLoggingViolation> = [];
+
+  function visit(node: ts.Node) {
+    if (ts.isCallExpression(node) && isLoggerCall(node)) {
+      for (const argument of node.arguments.slice(1)) {
+        violations.push(...analyzeLoggerArgument(sourceFile, filePath, argument));
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return violations;
+}
+
+export function formatPrivacyLoggingViolation(violation: PrivacyLoggingViolation): string {
+  return `${violation.filePath}:${violation.line}:${violation.column} - ${violation.message}`;
+}
+```
+
+- [ ] **Step 2: Run the privacy rule tests**
+
+Run:
+
+```bash
+pnpm privacy:logging:test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit the rule module and tests**
+
+Run:
+
+```bash
+git add package.json scripts/privacy-logging-rules.ts scripts/privacy-logging-rules.test.ts
+git commit -m "test: add privacy logging guard"
+```
+
+## Task 3: Privacy Logging CLI And Existing Log Sanitization
+
+**Files:**
+
+- Create: `scripts/validate-privacy-logging.ts`
+- Modify: source files reported by `pnpm privacy:logging`
+
+- [ ] **Step 1: Add the privacy logging CLI**
+
+Create `scripts/validate-privacy-logging.ts`:
+
+```typescript
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+import {
+  analyzePrivacyLoggingSource,
+  formatPrivacyLoggingViolation,
+  type PrivacyLoggingViolation,
+} from './privacy-logging-rules';
+
+const DEFAULT_ROOT = 'src';
+const VALID_EXTENSIONS = new Set(['.ts', '.tsx']);
+
+function getScanRoot(): string {
+  const rootIndex = process.argv.indexOf('--root');
+  if (rootIndex === -1) {
+    return DEFAULT_ROOT;
+  }
+
+  const root = process.argv[rootIndex + 1];
+  if (!root) {
+    throw new Error('--root requires a directory path');
+  }
+
+  return root;
+}
+
+function hasSupportedExtension(filePath: string): boolean {
+  return [...VALID_EXTENSIONS].some((extension) => filePath.endsWith(extension));
+}
+
+async function collectSourceFiles(directory: string): Promise<Array<string>> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: Array<string> = [];
+
+  for (const entry of entries) {
+    const fullPath = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') {
+        continue;
+      }
+      files.push(...(await collectSourceFiles(fullPath)));
+      continue;
+    }
+
+    if (entry.isFile() && hasSupportedExtension(fullPath)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+async function main() {
+  const root = getScanRoot();
+  const files = await collectSourceFiles(root);
+  const violations: Array<PrivacyLoggingViolation> = [];
+
+  for (const filePath of files) {
+    const sourceText = await readFile(filePath, 'utf8');
+    const relativePath = relative(process.cwd(), filePath);
+    violations.push(...analyzePrivacyLoggingSource(relativePath, sourceText));
+  }
+
+  if (violations.length === 0) {
+    console.log(`Privacy logging validation passed for ${files.length} files.`);
+    return;
+  }
+
+  console.error(`Privacy logging validation failed with ${violations.length} issue(s):`);
+  for (const violation of violations) {
+    console.error(formatPrivacyLoggingViolation(violation));
+  }
+
+  process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error('Privacy logging validation failed unexpectedly:');
+  console.error(error);
+  process.exitCode = 1;
+});
+```
+
+- [ ] **Step 2: Run the validator against current source**
+
+Run:
+
+```bash
+pnpm privacy:logging
+```
+
+Expected: FAIL. Current known unsafe patterns include these files:
+
+```text
+src/background/handlers/connection-handlers.ts
+src/background/handlers/scroll-sync-handlers.ts
+src/background/handlers/tab-event-handlers.ts
+src/background/lib/auto-sync-groups.ts
+src/background/lib/auto-sync-lifecycle.ts
+src/background/lib/auto-sync-suggestions.ts
+src/background/lib/sync-state.ts
+src/contentScripts/scroll-sync.ts
+```
+
+- [ ] **Step 3: Replace raw URL and payload logs with safe metadata**
+
+Use these replacements as the required pattern:
+
+```typescript
+// Unsafe
+logger.info('URL changed, broadcasting to other tabs', { url });
+
+// Safe
+logger.info('URL changed, broadcasting to other tabs', { tabId: syncState.tabId });
+```
+
+```typescript
+// Unsafe
+logger.info('Relaying URL sync message', { payload });
+
+// Safe
+logger.info('Relaying URL sync message', { sourceTabId: payload.sourceTabId });
+```
+
+```typescript
+// Unsafe
+logger.debug(`Verified tab ${tabId} exists:`, { title: tab.title, url: tab.url });
+
+// Safe
+logger.debug(`Verified tab ${tabId} exists`);
+```
+
+```typescript
+// Unsafe
+logger.debug('Relaying scroll sync message', { payload, sender });
+
+// Safe
+logger.debug('Relaying scroll sync message', {
+  sourceTabId: payload.sourceTabId,
+  mode: payload.mode,
+  hasSenderTab: sender.tabId !== undefined,
+});
+```
+
+```typescript
+// Unsafe
+logger.debug('Sync state persisted to storage', { syncState });
+
+// Safe
+logger.debug('Sync state persisted to storage', {
+  isActive: syncState.isActive,
+  linkedTabCount: syncState.linkedTabs.length,
+  mode: syncState.mode,
+});
+```
+
+```typescript
+// Unsafe
+logger.debug(`[AUTO-SYNC] URL is forbidden, skipping auto-sync`, { url, tabId });
+
+// Safe
+logger.debug('[AUTO-SYNC] URL is forbidden, skipping auto-sync', { tabId });
+```
+
+For normalized URL group logs, do not log the normalized URL itself. Use count and boolean metadata:
+
+```typescript
+// Unsafe
+logger.info('[AUTO-SYNC] Created new group', { normalizedUrl: groupKey });
+
+// Safe
+logger.info('[AUTO-SYNC] Created new group', {
+  tabId,
+  groupCount: autoSyncState.groups.size,
+});
+```
+
+- [ ] **Step 4: Re-run the validator**
+
+Run:
+
+```bash
+pnpm privacy:logging
+```
+
+Expected: PASS with a message like:
+
+```text
+Privacy logging validation passed for N files.
+```
+
+- [ ] **Step 5: Run focused regression tests for URL Sync and storage**
+
+Run:
+
+```bash
+pnpm test -- --run src/shared/lib/translated-page-url-utils.test.ts src/shared/lib/storage.test.ts src/__tests__/scenarios.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit sanitized logging**
+
+Run:
+
+```bash
+git add scripts/validate-privacy-logging.ts src/background src/contentScripts
+git commit -m "fix: sanitize privacy-sensitive logs"
+```
+
+## Task 4: Extension E2E Fixtures
+
+**Files:**
+
+- Create: `playwright.config.extension.ts`
+- Create: `e2e/extension/fixtures.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Add the extension E2E script**
+
+Add this script to `package.json`:
+
+```json
+{
+  "test:e2e:extension": "playwright test --config playwright.config.extension.ts"
+}
+```
+
+- [ ] **Step 2: Create the extension Playwright config**
+
+Create `playwright.config.extension.ts`:
+
+```typescript
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e/extension',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [['html', { open: 'never', outputFolder: 'playwright-report-extension' }]],
+  use: {
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+});
+```
+
+- [ ] **Step 3: Create extension and local server fixtures**
+
+Create `e2e/extension/fixtures.ts`:
+
+```typescript
+import { test as base, chromium, expect, type BrowserContext, type Page } from '@playwright/test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+interface FixtureSite {
+  name: string;
+  origin: string;
+  url: (path: string) => string;
+  close: () => Promise<void>;
+}
+
+interface ExtensionFixtures {
+  extensionContext: BrowserContext;
+  extensionId: string;
+  fixtureSites: {
+    primary: FixtureSite;
+    comparison: FixtureSite;
+  };
+  openPopup: () => Promise<Page>;
+}
+
+function titleFor(siteName: string, pathname: string): string {
+  const pageName = pathname.includes('/about') ? 'About' : 'Home';
+  return `${siteName} ${pageName}`;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function startFixtureSite(name: string): Promise<FixtureSite> {
+  const server = createServer((request, response) => {
+    const requestUrl = new URL(request.url ?? '/', 'http://127.0.0.1');
+    const title = titleFor(name, requestUrl.pathname);
+
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    response.end(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>${title}</title>
+  </head>
+  <body>
+    <main>
+      <h1>${title}</h1>
+      <p data-site="${name}" data-path="${requestUrl.pathname}">URL Sync fixture</p>
+      <div style="height: 2400px"></div>
+    </main>
+  </body>
+</html>`);
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error(`Fixture site ${name} did not expose a TCP address`);
+  }
+
+  const origin = `http://127.0.0.1:${address.port}`;
+
+  return {
+    name,
+    origin,
+    url: (path) => `${origin}${path}`,
+    close: () => closeServer(server),
+  };
+}
+
+async function getExtensionId(context: BrowserContext): Promise<string> {
+  let serviceWorker = context.serviceWorkers()[0];
+  if (!serviceWorker) {
+    serviceWorker = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  }
+
+  const extensionId = new URL(serviceWorker.url()).host;
+  if (!extensionId) {
+    throw new Error(
+      `Could not discover extension id from service worker URL: ${serviceWorker.url()}`,
+    );
+  }
+
+  return extensionId;
+}
+
+export const test = base.extend<ExtensionFixtures>({
+  fixtureSites: async ({}, use) => {
+    const primary = await startFixtureSite('Primary');
+    const comparison = await startFixtureSite('Comparison');
+
+    await use({ primary, comparison });
+
+    await Promise.all([primary.close(), comparison.close()]);
+  },
+
+  extensionContext: async ({}, use) => {
+    const extensionPath = resolve(process.env.EXTENSION_E2E_DIR ?? 'extension');
+    const userDataDir = await mkdtemp(join(tmpdir(), 'synchronize-tab-scrolling-e2e-'));
+
+    const context = await chromium.launchPersistentContext(userDataDir, {
+      channel: 'chromium',
+      args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`],
+    });
+
+    await use(context);
+
+    await context.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  },
+
+  extensionId: async ({ extensionContext }, use) => {
+    await use(await getExtensionId(extensionContext));
+  },
+
+  openPopup: async ({ extensionContext, extensionId }, use) => {
+    await use(async () => {
+      const popup = await extensionContext.newPage();
+      await popup.goto(`chrome-extension://${extensionId}/dist/popup/index.html`);
+      await expect(popup.getByRole('heading', { name: 'URL Sync' })).toBeVisible();
+      return popup;
+    });
+  },
+});
+
+export { expect };
+```
+
+- [ ] **Step 4: Run the fixture compile check**
+
+Run:
+
+```bash
+pnpm typecheck
+```
+
+Expected: PASS or fail only on issues inside the new fixture file. Fix fixture type issues before moving on.
+
+## Task 5: URL Sync Extension Smoke Tests
+
+**Files:**
+
+- Create: `e2e/extension/url-sync-modes.spec.ts`
+- Test: `playwright.config.extension.ts`
+
+- [ ] **Step 1: Write the URL Sync smoke spec**
+
+Create `e2e/extension/url-sync-modes.spec.ts`:
+
+```typescript
+import { test, expect } from './fixtures';
+
+import type { Page } from '@playwright/test';
+
+async function selectTabsAndStartSync(
+  popup: Page,
+  sourceTitle: string,
+  targetTitle: string,
+): Promise<void> {
+  await popup.getByRole('checkbox', { name: `Select ${sourceTitle}` }).click();
+  await popup.getByRole('checkbox', { name: `Select ${targetTitle}` }).click();
+  await popup.getByRole('button', { name: 'Start synchronization' }).click();
+  await expect(popup.getByRole('button', { name: 'Stop synchronization' })).toBeVisible();
+}
+
+async function chooseKeepEachTabsWebsiteMode(popup: Page): Promise<void> {
+  await popup.getByRole('radio', { name: /Keep each tab's website/ }).check();
+  await expect(popup.getByRole('radio', { name: /Keep each tab's website/ })).toBeChecked();
+}
+
+async function turnUrlSyncOff(popup: Page): Promise<void> {
+  await popup.getByRole('switch', { name: 'URL Sync' }).click();
+  await expect(popup.getByRole('switch', { name: 'URL Sync' })).not.toBeChecked();
+}
+
+test.describe('URL Sync modes', () => {
+  test('follow changed tab moves the target to the changed website while preserving language', async ({
+    extensionContext,
+    fixtureSites,
+    openPopup,
+  }) => {
+    const source = await extensionContext.newPage();
+    const target = await extensionContext.newPage();
+    const targetInitialUrl = fixtureSites.comparison.url('/ko/home?view=compact#comparison-home');
+
+    await source.goto(fixtureSites.primary.url('/en/home?view=compact#primary-home'));
+    await target.goto(targetInitialUrl);
+
+    const popup = await openPopup();
+    await expect(popup.getByRole('radio', { name: /Follow changed tab/ })).toBeChecked();
+    await selectTabsAndStartSync(popup, 'Primary Home', 'Comparison Home');
+
+    await source.goto(fixtureSites.primary.url('/en/about?tab=pricing#plans'));
+
+    await expect(target).toHaveURL(
+      fixtureSites.primary.url('/ko/about?tab=pricing#comparison-home'),
+    );
+  });
+
+  test('keep each tabs website keeps the target origin while applying the changed page', async ({
+    extensionContext,
+    fixtureSites,
+    openPopup,
+  }) => {
+    const source = await extensionContext.newPage();
+    const target = await extensionContext.newPage();
+    const targetInitialUrl = fixtureSites.comparison.url('/ko/home?view=compact#comparison-home');
+
+    await source.goto(fixtureSites.primary.url('/en/home?view=compact#primary-home'));
+    await target.goto(targetInitialUrl);
+
+    const popup = await openPopup();
+    await chooseKeepEachTabsWebsiteMode(popup);
+    await selectTabsAndStartSync(popup, 'Primary Home', 'Comparison Home');
+
+    await source.goto(fixtureSites.primary.url('/en/about?tab=pricing#plans'));
+
+    await expect(target).toHaveURL(
+      fixtureSites.comparison.url('/ko/about?tab=pricing#comparison-home'),
+    );
+  });
+
+  test('url sync off keeps the target on its current URL', async ({
+    extensionContext,
+    fixtureSites,
+    openPopup,
+  }) => {
+    const source = await extensionContext.newPage();
+    const target = await extensionContext.newPage();
+    const targetInitialUrl = fixtureSites.comparison.url('/ko/home?view=compact#comparison-home');
+
+    await source.goto(fixtureSites.primary.url('/en/home?view=compact#primary-home'));
+    await target.goto(targetInitialUrl);
+
+    const popup = await openPopup();
+    await turnUrlSyncOff(popup);
+    await selectTabsAndStartSync(popup, 'Primary Home', 'Comparison Home');
+
+    await source.goto(fixtureSites.primary.url('/en/about?tab=pricing#plans'));
+
+    const didNavigate = await target
+      .waitForURL((url) => url.href !== targetInitialUrl, { timeout: 1_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    expect(didNavigate).toBe(false);
+    await expect(target).toHaveURL(targetInitialUrl);
+  });
+
+  test('selected mode remains visible when the popup is reopened', async ({
+    extensionContext,
+    fixtureSites,
+    openPopup,
+  }) => {
+    const source = await extensionContext.newPage();
+    const target = await extensionContext.newPage();
+
+    await source.goto(fixtureSites.primary.url('/en/home'));
+    await target.goto(fixtureSites.comparison.url('/ko/home'));
+
+    const firstPopup = await openPopup();
+    await chooseKeepEachTabsWebsiteMode(firstPopup);
+    await firstPopup.close();
+
+    const secondPopup = await openPopup();
+    await expect(secondPopup.getByRole('radio', { name: /Keep each tab's website/ })).toBeChecked();
+    await expect(secondPopup.getByText('Languages are kept when possible.')).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Build the Chromium extension and run the smoke tests**
+
+Run:
+
+```bash
+pnpm build
+pnpm test:e2e:extension
+```
+
+Expected: PASS. If Chromium is not installed locally, run:
+
+```bash
+pnpm exec playwright install chromium
+pnpm test:e2e:extension
+```
+
+- [ ] **Step 3: Commit the extension E2E test suite**
+
+Run:
+
+```bash
+git add package.json playwright.config.extension.ts e2e/extension
+git commit -m "test: add URL sync extension smoke tests"
+```
+
+## Task 6: Required GitHub Actions Gate
+
+**Files:**
+
+- Create: `.github/workflows/extension-pr-checks.yml`
+- Modify: `package.json`
+
+- [ ] **Step 1: Add the non-mutating lint script**
+
+Add this script to `package.json`:
+
+```json
+{
+  "lint:check": "NODE_OPTIONS='--experimental-strip-types' eslint . --flag unstable_native_nodejs_ts_config --max-warnings=0"
+}
+```
+
+- [ ] **Step 2: Create the required workflow**
+
+Create `.github/workflows/extension-pr-checks.yml`:
+
+```yaml
+name: Extension PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  extension-pr-checks:
+    name: extension-pr-checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect extension-impacting changes
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+
+          echo "Changed files:"
+          if [ -n "$changed_files" ]; then
+            echo "$changed_files" | sed 's/^/- /'
+          else
+            echo "- none"
+          fi
+
+          extension_changed=false
+
+          while IFS= read -r file; do
+            case "$file" in
+              .github/workflows/extension-pr-checks.yml)
+                extension_changed=true
+                ;;
+              e2e/*)
+                extension_changed=true
+                ;;
+              extension/_locales/*)
+                extension_changed=true
+                ;;
+              package.json)
+                extension_changed=true
+                ;;
+              pnpm-lock.yaml)
+                extension_changed=true
+                ;;
+              playwright.config.ts)
+                extension_changed=true
+                ;;
+              playwright.config.extension.ts)
+                extension_changed=true
+                ;;
+              scripts/*)
+                extension_changed=true
+                ;;
+              src/background/*)
+                extension_changed=true
+                ;;
+              src/contentScripts/*)
+                extension_changed=true
+                ;;
+              src/manifest.ts)
+                extension_changed=true
+                ;;
+              src/popup/*)
+                extension_changed=true
+                ;;
+              src/shared/*)
+                extension_changed=true
+                ;;
+              tsconfig*.json)
+                extension_changed=true
+                ;;
+              uno.config.ts)
+                extension_changed=true
+                ;;
+              vite.config*.mts)
+                extension_changed=true
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          echo "extension_changed=$extension_changed" >> "$GITHUB_OUTPUT"
+
+      - name: No extension-impacting changes
+        if: steps.changes.outputs.extension_changed != 'true'
+        run: echo "No extension-impacting changes detected."
+
+      - uses: pnpm/action-setup@v5
+        if: steps.changes.outputs.extension_changed == 'true'
+
+      - uses: actions/setup-node@v6
+        if: steps.changes.outputs.extension_changed == 'true'
+        with:
+          node-version: 'lts/*'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate privacy-safe logging
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm privacy:logging
+
+      - name: Validate i18n
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm i18n:validate
+
+      - name: Typecheck
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm typecheck
+
+      - name: Lint
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm lint:check
+
+      - name: Unit tests
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm test -- --run
+
+      - name: Build Chromium extension
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm build
+
+      - name: Preserve Chromium extension build for E2E
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: |
+          rm -rf test-results/chromium-extension
+          mkdir -p test-results/chromium-extension
+          cp -R extension/. test-results/chromium-extension/
+
+      - name: Build Firefox extension
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm build-firefox
+
+      - name: Install Playwright Chromium
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: URL Sync extension smoke tests
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm test:e2e:extension
+        env:
+          EXTENSION_E2E_DIR: test-results/chromium-extension
+
+      - name: Upload extension Playwright report
+        if: failure() && steps.changes.outputs.extension_changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-playwright-report
+          path: playwright-report-extension/
+          retention-days: 7
+```
+
+- [ ] **Step 3: Verify the workflow has no privileged trigger**
+
+Run:
+
+```bash
+rg -n "pull_request_target|permissions:.*write|GITHUB_TOKEN|secrets\\." .github/workflows/extension-pr-checks.yml
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit the CI workflow**
+
+Run:
+
+```bash
+git add package.json .github/workflows/extension-pr-checks.yml
+git commit -m "ci: add extension PR checks gate"
+```
+
+## Task 7: Full Verification
+
+**Files:**
+
+- Verify all files changed by Tasks 1 through 6.
+
+- [ ] **Step 1: Run the static privacy checks**
+
+Run:
+
+```bash
+pnpm privacy:logging:test
+pnpm privacy:logging
+```
+
+Expected: both PASS.
+
+- [ ] **Step 2: Run repository health checks used by the new gate**
+
+Run:
+
+```bash
+pnpm i18n:validate
+pnpm typecheck
+pnpm lint:check
+pnpm test -- --run
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Verify both production builds and preserve the Chromium build**
+
+Run:
+
+```bash
+pnpm build
+rm -rf test-results/chromium-extension
+mkdir -p test-results/chromium-extension
+cp -R extension/. test-results/chromium-extension/
+pnpm build-firefox
+```
+
+Expected: both builds PASS.
+
+- [ ] **Step 4: Run extension smoke E2E against the preserved Chromium build**
+
+Run:
+
+```bash
+EXTENSION_E2E_DIR=test-results/chromium-extension pnpm test:e2e:extension
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify workflow security and check naming**
+
+Run:
+
+```bash
+rg -n "name: extension-pr-checks|pull_request_target|contents: read|secrets\\." .github/workflows/extension-pr-checks.yml
+```
+
+Expected output includes:
+
+```text
+name: extension-pr-checks
+contents: read
+```
+
+Expected output does not include:
+
+```text
+pull_request_target
+secrets.
+```
+
+- [ ] **Step 6: Verify the working tree and branch history**
+
+Run:
+
+```bash
+git status --short
+git log --oneline main..HEAD
+```
+
+Expected:
+
+```text
+git status --short
+```
+
+prints no output after all intended files are committed.
+
+## Commit Order
+
+1. `test: add privacy logging guard`
+2. `fix: sanitize privacy-sensitive logs`
+3. `test: add URL sync extension smoke tests`
+4. `ci: add extension PR checks gate`
+
+## Acceptance Checklist
+
+- [ ] Every pull request gets a required status check named `extension-pr-checks`.
+- [ ] Landing-only PRs finish `extension-pr-checks` successfully without running the full gate.
+- [ ] Extension-impacting PRs run privacy logging validation, i18n validation, typecheck, lint, unit tests, Chromium build, Firefox build, and URL Sync smoke E2E.
+- [ ] CI uses `pull_request`, not `pull_request_target`.
+- [ ] CI permissions remain `contents: read`.
+- [ ] CI does not use repository admin tokens or modify rulesets.
+- [ ] Raw URL, title, payload, full tab, and full sync state logging fails the static validator.
+- [ ] Existing source logs pass the privacy validator.
+- [ ] `Follow changed tab` and `Keep each tab's website` behavior is covered in a real extension context.
+- [ ] URL Sync off prevents navigation in the smoke test.
+- [ ] Popup mode visibility and persistence are covered.

--- a/docs/superpowers/plans/2026-06-28-extension-pr-checks.md
+++ b/docs/superpowers/plans/2026-06-28-extension-pr-checks.md
@@ -167,7 +167,7 @@ Expected: FAIL because `scripts/privacy-logging-rules.ts` does not exist.
 Create `scripts/privacy-logging-rules.ts`:
 
 ```typescript
-import ts from 'typescript';
+import * as ts from 'typescript';
 
 export interface PrivacyLoggingViolation {
   filePath: string;
@@ -1043,10 +1043,7 @@ jobs:
               pnpm-lock.yaml)
                 extension_changed=true
                 ;;
-              playwright.config.ts)
-                extension_changed=true
-                ;;
-              playwright.config.extension.ts)
+              playwright.config*.ts)
                 extension_changed=true
                 ;;
               scripts/*)
@@ -1073,7 +1070,7 @@ jobs:
               uno.config.ts)
                 extension_changed=true
                 ;;
-              vite.config*.mts)
+              vite.config*)
                 extension_changed=true
                 ;;
             esac
@@ -1097,6 +1094,10 @@ jobs:
       - name: Install dependencies
         if: steps.changes.outputs.extension_changed == 'true'
         run: pnpm install --frozen-lockfile
+
+      - name: Test privacy-safe logging validator
+        if: steps.changes.outputs.extension_changed == 'true'
+        run: pnpm privacy:logging:test
 
       - name: Validate privacy-safe logging
         if: steps.changes.outputs.extension_changed == 'true'
@@ -1125,9 +1126,9 @@ jobs:
       - name: Preserve Chromium extension build for E2E
         if: steps.changes.outputs.extension_changed == 'true'
         run: |
-          rm -rf test-results/chromium-extension
-          mkdir -p test-results/chromium-extension
-          cp -R extension/. test-results/chromium-extension/
+          rm -rf .extension-e2e/chromium-extension
+          mkdir -p .extension-e2e/chromium-extension
+          cp -R extension/. .extension-e2e/chromium-extension/
 
       - name: Build Firefox extension
         if: steps.changes.outputs.extension_changed == 'true'
@@ -1141,7 +1142,7 @@ jobs:
         if: steps.changes.outputs.extension_changed == 'true'
         run: pnpm test:e2e:extension
         env:
-          EXTENSION_E2E_DIR: test-results/chromium-extension
+          EXTENSION_E2E_DIR: .extension-e2e/chromium-extension
 
       - name: Upload extension Playwright report
         if: failure() && steps.changes.outputs.extension_changed == 'true'
@@ -1207,9 +1208,9 @@ Run:
 
 ```bash
 pnpm build
-rm -rf test-results/chromium-extension
-mkdir -p test-results/chromium-extension
-cp -R extension/. test-results/chromium-extension/
+rm -rf .extension-e2e/chromium-extension
+mkdir -p .extension-e2e/chromium-extension
+cp -R extension/. .extension-e2e/chromium-extension/
 pnpm build-firefox
 ```
 
@@ -1220,7 +1221,7 @@ Expected: both builds PASS.
 Run:
 
 ```bash
-EXTENSION_E2E_DIR=test-results/chromium-extension pnpm test:e2e:extension
+EXTENSION_E2E_DIR=.extension-e2e/chromium-extension pnpm test:e2e:extension
 ```
 
 Expected: PASS.

--- a/docs/superpowers/specs/2026-06-28-extension-pr-checks-design.md
+++ b/docs/superpowers/specs/2026-06-28-extension-pr-checks-design.md
@@ -88,7 +88,7 @@ Extension-impacting paths:
 - `extension/_locales/**`
 - `package.json`
 - `pnpm-lock.yaml`
-- `playwright.config.ts`
+- `playwright.config*.ts`
 - `scripts/**`
 - `src/background/**`
 - `src/contentScripts/**`
@@ -97,7 +97,7 @@ Extension-impacting paths:
 - `src/shared/**`
 - `tsconfig*.json`
 - `uno.config.ts`
-- `vite.config*.mts`
+- `vite.config*`
 
 Landing-only changes should still produce a successful `extension-pr-checks` status, but the job
 should exit after a short message such as:
@@ -117,21 +117,24 @@ When extension-impacting files changed, run the gate in this order:
 2. Set up pnpm with the repository's package manager version.
 3. Set up Node.js with pnpm caching.
 4. Run `pnpm install --frozen-lockfile`.
-5. Run the static privacy logging check.
-6. Run `pnpm i18n:validate`.
-7. Run `pnpm typecheck`.
-8. Run a non-mutating lint check.
-9. Run `pnpm test -- --run`.
-10. Run `pnpm build`.
-11. Run `pnpm build-firefox`.
-12. Run the extension URL Sync smoke E2E test.
+5. Run `pnpm privacy:logging:test`.
+6. Run the static privacy logging check.
+7. Run `pnpm i18n:validate`.
+8. Run `pnpm typecheck`.
+9. Run a non-mutating lint check.
+10. Run `pnpm test -- --run`.
+11. Run `pnpm build`.
+12. Run `pnpm build-firefox`.
+13. Run the extension URL Sync smoke E2E test.
 
 Add missing package scripts instead of embedding long commands in the workflow. At minimum, add:
 
 ```json
 {
-  "lint:check": "NODE_OPTIONS='--experimental-strip-types' eslint . --flag unstable_native_nodejs_ts_config --max-warnings=0",
+  "build-firefox": "cross-env NODE_ENV=production EXTENSION=firefox run-s clear i18n:validate build:web build:prepare build:background build:js",
+  "lint:check": "NODE_OPTIONS='--experimental-strip-types' eslint src/background src/contentScripts src/popup src/shared src/manifest.ts scripts e2e '*.ts' '*.mts' --flag unstable_native_nodejs_ts_config --max-warnings=0",
   "privacy:logging": "esno scripts/validate-privacy-logging.ts",
+  "privacy:logging:test": "vitest run --root . scripts/privacy-logging-rules.test.ts",
   "test:e2e:extension": "playwright test --config playwright.config.extension.ts"
 }
 ```

--- a/docs/superpowers/specs/2026-06-28-extension-pr-checks-design.md
+++ b/docs/superpowers/specs/2026-06-28-extension-pr-checks-design.md
@@ -1,0 +1,325 @@
+# Extension PR Checks Design
+
+## Context
+
+Issue #384 introduced a URL Sync mode that changes how synchronized tabs navigate between
+websites. The feature passed manual testing, but repeating that matrix before every merge is not
+realistic.
+
+The repository currently has separate push-time workflows:
+
+- `release.yml` for extension releases after changes land on `main`
+- `deploy-landing.yml` for landing page deployment
+- `update-store-stats.yml` for scheduled store statistics
+
+None of those workflows is a required pull request gate for extension changes. The repository
+ruleset now requires a status check named `extension-pr-checks`, so CI must provide that exact check
+name and keep it stable.
+
+The gate must protect the extension without weakening the existing release and landing pipeline
+isolation. It must not use privileged pull request execution, mutate repository settings, or depend
+on manual browser testing.
+
+## Goal
+
+Add a required pull request CI gate named `extension-pr-checks` for extension-impacting changes.
+
+The gate should combine:
+
+- fast static and unit checks
+- both Chromium and Firefox production builds
+- a focused extension E2E smoke test for URL Sync modes
+- a static privacy logging check that rejects raw URL, title, and payload logging
+
+The result should make regressions in URL Sync behavior expensive to merge while keeping ordinary PR
+feedback fast enough to run on every pull request.
+
+## Non-Goals
+
+- Do not let CI configure branch protection, rulesets, required checks, labels, or other repository
+  settings.
+- Do not add a local script for configuring repository rulesets.
+- Do not use `pull_request_target`.
+- Do not run the full manual URL Sync matrix on every pull request.
+- Do not depend on external public websites for E2E tests.
+- Do not merge the extension release workflow and landing deployment workflow.
+- Do not broaden CI permissions beyond what the check needs to read code and run tests.
+
+## Required Check Shape
+
+Create a new workflow:
+
+```text
+.github/workflows/extension-pr-checks.yml
+```
+
+Use a stable workflow/job shape:
+
+```yaml
+name: Extension PR Checks
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  extension-pr-checks:
+    name: extension-pr-checks
+```
+
+The job name must stay exactly `extension-pr-checks` because repository rulesets match that status
+check.
+
+Do not use workflow-level path filters. If a required workflow is path-filtered and does not run,
+GitHub can leave the required check pending and block unrelated pull requests. Instead, always run
+the job and decide inside the job whether extension checks are necessary.
+
+## Change Detection
+
+Inside `extension-pr-checks`, compute whether the pull request touches extension-impacting files.
+
+Extension-impacting paths:
+
+- `.github/workflows/extension-pr-checks.yml`
+- `e2e/**`
+- `extension/_locales/**`
+- `package.json`
+- `pnpm-lock.yaml`
+- `playwright.config.ts`
+- `scripts/**`
+- `src/background/**`
+- `src/contentScripts/**`
+- `src/manifest.ts`
+- `src/popup/**`
+- `src/shared/**`
+- `tsconfig*.json`
+- `uno.config.ts`
+- `vite.config*.mts`
+
+Landing-only changes should still produce a successful `extension-pr-checks` status, but the job
+should exit after a short message such as:
+
+```text
+No extension-impacting changes detected.
+```
+
+This keeps the required check truthful without making landing-only pull requests wait for extension
+builds.
+
+## CI Steps
+
+When extension-impacting files changed, run the gate in this order:
+
+1. Check out the pull request code.
+2. Set up pnpm with the repository's package manager version.
+3. Set up Node.js with pnpm caching.
+4. Run `pnpm install --frozen-lockfile`.
+5. Run the static privacy logging check.
+6. Run `pnpm i18n:validate`.
+7. Run `pnpm typecheck`.
+8. Run a non-mutating lint check.
+9. Run `pnpm test -- --run`.
+10. Run `pnpm build`.
+11. Run `pnpm build-firefox`.
+12. Run the extension URL Sync smoke E2E test.
+
+Add missing package scripts instead of embedding long commands in the workflow. At minimum, add:
+
+```json
+{
+  "lint:check": "NODE_OPTIONS='--experimental-strip-types' eslint . --flag unstable_native_nodejs_ts_config --max-warnings=0",
+  "privacy:logging": "esno scripts/validate-privacy-logging.ts",
+  "test:e2e:extension": "playwright test --config playwright.config.extension.ts"
+}
+```
+
+## Static Privacy Logging Check
+
+Raw URLs and titles are user data. The CI gate should validate this statically rather than trying to
+observe console output in E2E.
+
+Add a small validator:
+
+```text
+scripts/validate-privacy-logging.ts
+```
+
+The validator should inspect TypeScript and TSX files under `src/**` and fail on unsafe logger
+calls.
+
+It should reject logger metadata that contains raw browser data, including:
+
+- object keys such as `url`, `sourceUrl`, `targetUrl`, `normalizedUrl`, `payload`, `tab`, `title`,
+  `tabTitle`, `documentTitle`, `canonicalUrl`, and `alternateUrls`
+- shorthand metadata such as `{ payload }` or `{ tab }`
+- direct expressions such as `window.location.href`, `tab.url`, `payload.url`, and `document.title`
+- whole objects or identifiers that are likely to contain URLs, titles, page metadata, or storage
+  payloads
+
+It should allow non-sensitive metadata, including:
+
+- `tabId`
+- `sourceTabId`
+- `targetTabId`
+- `mode`
+- `reason`
+- counts
+- booleans
+- enum/status strings
+
+If a domain is truly required, log a sanitized `domain` value only. Never log path, query, hash,
+tab title, page title, canonical URL, alternate URL, or the full payload object.
+
+The validator should report file, line, and a clear remediation hint. A failure should read like a
+code review comment, not a generic grep failure.
+
+## URL Sync Smoke E2E
+
+Add an extension-specific Playwright config and spec:
+
+```text
+playwright.config.extension.ts
+e2e/extension/url-sync-modes.spec.ts
+```
+
+The test should load the built Chromium extension in a persistent browser context with:
+
+- `--disable-extensions-except=<extension-dir>`
+- `--load-extension=<extension-dir>`
+
+The test should use local deterministic fixture pages instead of public websites. The fixtures need
+enough URL variety to exercise the product behavior:
+
+- same website, different language
+- different website boundary, same matching page
+- path movement
+- query-language carrier
+- hash preservation when applicable
+
+Different websites can be represented with local origins, such as different loopback hosts or ports,
+as long as the test validates the same browser-visible behavior the extension uses.
+
+### Smoke Cases
+
+The required smoke suite should cover these cases:
+
+1. `Follow changed tab`
+   - Another tab follows the changed tab's website.
+   - The target tab's language is preserved when possible.
+2. `Keep each tab's website`
+   - Another tab stays on its own website.
+   - The changed page movement is applied within that website.
+   - The target tab's language is preserved when possible.
+3. URL Sync off
+   - The other tab does not navigate when the source tab changes URL.
+4. Mode visibility
+   - The active mode is visible in the extension UI.
+   - The persisted mode shown in UI matches the mode that actually drives behavior.
+
+The E2E test should not validate privacy logging. That belongs in the static validator because it is
+more complete, faster, and less dependent on runtime coverage.
+
+## State Truthfulness
+
+The CI tests should enforce the same state truthfulness rule as the product:
+
+- If a mode cannot be stored, restored, or applied, UI must not pretend that mode is active.
+- If the extension falls back to a different effective behavior, UI must show the effective state or
+  present an actionable error.
+- A test failure should point to the mismatch between requested mode, stored mode, displayed mode,
+  and effective navigation behavior.
+
+This is especially important for `Keep each tab's website`, because silently behaving like `Follow
+changed tab` would be worse than disabling URL Sync with a clear message.
+
+## Repository Settings
+
+Repository settings stay manual.
+
+The required manual setting is already configured:
+
+- Ruleset or branch protection target: `main`
+- Required status check: `extension-pr-checks`
+- Pull request merge blocked while `extension-pr-checks` fails or is pending
+
+CI should not receive a GitHub admin token and should not edit repository rules. This avoids a
+privilege escalation path where a workflow could weaken the protection that it is supposed to
+enforce.
+
+## Failure Messages
+
+Failures should be actionable for a non-maintainer reading the pull request.
+
+Examples:
+
+```text
+Unsafe logger metadata in src/background/example.ts:42
+Do not log "sourceUrl". Log tabId, mode, reason, or sanitized domain instead.
+```
+
+```text
+URL Sync mode mismatch
+Requested: keep-each-tabs-website
+Displayed: keep-each-tabs-website
+Effective navigation: follow-changed-tab
+Expected the target tab to keep its own website.
+```
+
+```text
+Extension smoke test setup failed
+The Chromium extension ID could not be discovered after loading dist/.
+Check that pnpm build completed and the manifest is present.
+```
+
+## Acceptance Criteria
+
+- Every pull request receives a status check named `extension-pr-checks`.
+- A landing-only pull request gets a successful `extension-pr-checks` result without running the full
+  extension gate.
+- An extension-impacting pull request runs install, privacy logging validation, i18n validation,
+  typecheck, lint check, unit tests, Chromium build, Firefox build, and URL Sync smoke E2E.
+- Introducing `logger.info(..., { url: tab.url })` or equivalent raw URL metadata fails CI.
+- Regressing `Keep each tab's website` into `Follow changed tab` behavior fails CI.
+- Regressing mode UI visibility or persisted/effective mode truthfulness fails CI.
+- The workflow uses `pull_request`, not `pull_request_target`.
+- The workflow has read-only repository permissions.
+- Repository ruleset configuration remains outside CI.
+
+## Risks And Mitigations
+
+### Required check name mismatch
+
+If the job name changes, GitHub rulesets may wait for a check that never appears.
+
+Mitigation: keep both the job id and display name as `extension-pr-checks`.
+
+### Required path-filter deadlock
+
+If the required workflow is skipped by path filters, unrelated PRs can be blocked.
+
+Mitigation: do not path-filter the workflow trigger. Always run the required job and skip internally
+with a successful result when extension files did not change.
+
+### E2E flakiness
+
+Browser extension tests can be slower and more brittle than unit tests.
+
+Mitigation: keep the required E2E suite small, use local fixtures, avoid network dependencies, and
+capture traces or screenshots on failure.
+
+### Static validator false positives
+
+Privacy checks can become noisy if implemented as broad text search.
+
+Mitigation: inspect logger calls structurally with TypeScript syntax, keep the banned metadata list
+focused, and allow clearly sanitized fields such as `domain`, `tabId`, `mode`, and `reason`.
+
+### CI duration
+
+Running two production builds plus E2E can slow PR feedback.
+
+Mitigation: run the full gate only for extension-impacting changes and keep the E2E suite to smoke
+coverage for URL Sync modes.

--- a/e2e/extension/fixtures.ts
+++ b/e2e/extension/fixtures.ts
@@ -1,0 +1,143 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { test as base, chromium, expect, type BrowserContext, type Page } from '@playwright/test';
+
+interface FixtureSite {
+  name: string;
+  origin: string;
+  url: (path: string) => string;
+  close: () => Promise<void>;
+}
+
+interface ExtensionFixtures {
+  extensionContext: BrowserContext;
+  extensionId: string;
+  fixtureSites: {
+    primary: FixtureSite;
+    comparison: FixtureSite;
+  };
+  openPopup: () => Promise<Page>;
+}
+
+const URL_SYNC_HEADING_NAME = /URL Sync|URL 동기화 여부/i;
+
+function titleFor(siteName: string, pathname: string): string {
+  const pageName = pathname.includes('/about') ? 'About' : 'Home';
+  return `${siteName} ${pageName}`;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+async function startFixtureSite(name: string): Promise<FixtureSite> {
+  const server = createServer((request, response) => {
+    const requestUrl = new URL(request.url ?? '/', 'http://127.0.0.1');
+    const title = titleFor(name, requestUrl.pathname);
+
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    response.end(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>${title}</title>
+  </head>
+  <body>
+    <main>
+      <h1>${title}</h1>
+      <p data-site="${name}" data-path="${requestUrl.pathname}">URL Sync fixture</p>
+      <div style="height: 2400px"></div>
+    </main>
+  </body>
+</html>`);
+  });
+
+  await new Promise<void>((resolveListen) => {
+    server.listen(0, '127.0.0.1', resolveListen);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error(`Fixture site ${name} did not expose a TCP address`);
+  }
+
+  const origin = `http://127.0.0.1:${address.port}`;
+
+  return {
+    name,
+    origin,
+    url: (path) => `${origin}${path}`,
+    close: () => closeServer(server),
+  };
+}
+
+async function getExtensionId(context: BrowserContext): Promise<string> {
+  let serviceWorker = context.serviceWorkers()[0];
+  if (!serviceWorker) {
+    serviceWorker = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  }
+
+  const extensionId = new URL(serviceWorker.url()).host;
+  if (!extensionId) {
+    throw new Error(
+      `Could not discover extension id from service worker URL: ${serviceWorker.url()}`,
+    );
+  }
+
+  return extensionId;
+}
+
+export const test = base.extend<ExtensionFixtures>({
+  fixtureSites: async ({}, run) => {
+    const primary = await startFixtureSite('Primary');
+    const comparison = await startFixtureSite('Comparison');
+
+    await run({ primary, comparison });
+
+    await Promise.all([primary.close(), comparison.close()]);
+  },
+
+  extensionContext: async ({}, run) => {
+    const extensionPath = resolve(process.env.EXTENSION_E2E_DIR ?? 'extension');
+    const userDataDir = await mkdtemp(join(tmpdir(), 'synchronize-tab-scrolling-e2e-'));
+
+    const context = await chromium.launchPersistentContext(userDataDir, {
+      channel: 'chromium',
+      args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`],
+    });
+
+    await run(context);
+
+    await context.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  },
+
+  extensionId: async ({ extensionContext }, run) => {
+    await run(await getExtensionId(extensionContext));
+  },
+
+  openPopup: async ({ extensionContext, extensionId }, run) => {
+    await run(async () => {
+      const popup = await extensionContext.newPage();
+      await popup.goto(`chrome-extension://${extensionId}/dist/popup/index.html`);
+      await expect(popup.getByRole('heading', { name: URL_SYNC_HEADING_NAME })).toBeVisible();
+      return popup;
+    });
+  },
+});
+
+export { expect };

--- a/e2e/extension/url-sync-modes.spec.ts
+++ b/e2e/extension/url-sync-modes.spec.ts
@@ -10,17 +10,22 @@ const START_SYNC_NAME = /Start synchronization|동기화 시작/i;
 const STOP_SYNC_NAME = /Stop synchronization|동기화 중지/i;
 const URL_SYNC_SWITCH_NAME = /URL Sync|URL 동기화 여부/i;
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function selectTabCheckboxName(tabTitle: string): RegExp {
+  const escapedTitle = escapeRegExp(tabTitle);
+  return new RegExp(`^(?:Select ${escapedTitle}|${escapedTitle} 선택)$`);
+}
+
 async function selectTabsAndStartSync(
   popup: Page,
   sourceTitle: string,
   targetTitle: string,
 ): Promise<void> {
-  await popup
-    .getByRole('checkbox', { name: new RegExp(`Select ${sourceTitle}|${sourceTitle} 선택`) })
-    .click();
-  await popup
-    .getByRole('checkbox', { name: new RegExp(`Select ${targetTitle}|${targetTitle} 선택`) })
-    .click();
+  await popup.getByRole('checkbox', { name: selectTabCheckboxName(sourceTitle) }).click();
+  await popup.getByRole('checkbox', { name: selectTabCheckboxName(targetTitle) }).click();
   await popup.getByRole('button', { name: START_SYNC_NAME }).click();
   await expect(popup.getByRole('button', { name: STOP_SYNC_NAME })).toBeVisible();
 }

--- a/e2e/extension/url-sync-modes.spec.ts
+++ b/e2e/extension/url-sync-modes.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect } from './fixtures';
+
+import type { Page } from '@playwright/test';
+
+const FOLLOW_CHANGED_TAB_NAME = /Follow changed tab|변경한 탭 따라가기/i;
+const KEEP_EACH_TABS_WEBSITE_NAME = /Keep each tab's website|각 탭의 웹사이트 유지/i;
+const LANGUAGE_HELPER_COPY =
+  /Languages are kept when possible\.|가능한 경우 언어 설정은 유지됩니다\./i;
+const START_SYNC_NAME = /Start synchronization|동기화 시작/i;
+const STOP_SYNC_NAME = /Stop synchronization|동기화 중지/i;
+const URL_SYNC_SWITCH_NAME = /URL Sync|URL 동기화 여부/i;
+
+async function selectTabsAndStartSync(
+  popup: Page,
+  sourceTitle: string,
+  targetTitle: string,
+): Promise<void> {
+  await popup
+    .getByRole('checkbox', { name: new RegExp(`Select ${sourceTitle}|${sourceTitle} 선택`) })
+    .click();
+  await popup
+    .getByRole('checkbox', { name: new RegExp(`Select ${targetTitle}|${targetTitle} 선택`) })
+    .click();
+  await popup.getByRole('button', { name: START_SYNC_NAME }).click();
+  await expect(popup.getByRole('button', { name: STOP_SYNC_NAME })).toBeVisible();
+}
+
+async function chooseKeepEachTabsWebsiteMode(popup: Page): Promise<void> {
+  const keepWebsiteRadio = popup.getByRole('radio', { name: KEEP_EACH_TABS_WEBSITE_NAME });
+
+  await popup.getByText(KEEP_EACH_TABS_WEBSITE_NAME).click();
+  await expect(keepWebsiteRadio).toBeChecked();
+}
+
+async function turnUrlSyncOff(popup: Page): Promise<void> {
+  const urlSyncSwitch = popup.getByRole('switch', { name: URL_SYNC_SWITCH_NAME });
+
+  await urlSyncSwitch.click();
+  await expect(urlSyncSwitch).not.toBeChecked();
+}
+
+test.describe('URL Sync modes', () => {
+  test('default Follow changed tab moves target to source website while preserving target language and hash', async ({
+    extensionContext,
+    fixtureSites,
+    openPopup,
+  }) => {
+    const source = await extensionContext.newPage();
+    const target = await extensionContext.newPage();
+
+    await source.goto(fixtureSites.primary.url('/en/home?view=compact#primary-home'));
+    await target.goto(fixtureSites.comparison.url('/ko/home?view=compact#comparison-home'));
+
+    const popup = await openPopup();
+    await expect(popup.getByRole('radio', { name: FOLLOW_CHANGED_TAB_NAME })).toBeChecked();
+    await selectTabsAndStartSync(popup, 'Primary Home', 'Comparison Home');
+
+    await source.goto(fixtureSites.primary.url('/en/about?tab=pricing#plans'));
+
+    await expect(target).toHaveURL(
+      fixtureSites.primary.url('/ko/about?tab=pricing#comparison-home'),
+    );
+  });
+
+  test("Keep each tab's website keeps target origin while applying changed page", async ({
+    extensionContext,
+    fixtureSites,
+    openPopup,
+  }) => {
+    const source = await extensionContext.newPage();
+    const target = await extensionContext.newPage();
+
+    await source.goto(fixtureSites.primary.url('/en/home?view=compact#primary-home'));
+    await target.goto(fixtureSites.comparison.url('/ko/home?view=compact#comparison-home'));
+
+    const popup = await openPopup();
+    await chooseKeepEachTabsWebsiteMode(popup);
+    await selectTabsAndStartSync(popup, 'Primary Home', 'Comparison Home');
+
+    await source.goto(fixtureSites.primary.url('/en/about?tab=pricing#plans'));
+
+    await expect(target).toHaveURL(
+      fixtureSites.comparison.url('/ko/about?tab=pricing#comparison-home'),
+    );
+  });
+
+  test('URL Sync off prevents target navigation', async ({
+    extensionContext,
+    fixtureSites,
+    openPopup,
+  }) => {
+    const source = await extensionContext.newPage();
+    const target = await extensionContext.newPage();
+    const targetInitialUrl = fixtureSites.comparison.url('/ko/home?view=compact#comparison-home');
+
+    await source.goto(fixtureSites.primary.url('/en/home?view=compact#primary-home'));
+    await target.goto(targetInitialUrl);
+
+    const popup = await openPopup();
+    await turnUrlSyncOff(popup);
+    await selectTabsAndStartSync(popup, 'Primary Home', 'Comparison Home');
+
+    await source.goto(fixtureSites.primary.url('/en/about?tab=pricing#plans'));
+
+    const didNavigate = await target
+      .waitForURL((url) => url.href !== targetInitialUrl, { timeout: 1_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    expect(didNavigate).toBe(false);
+    await expect(target).toHaveURL(targetInitialUrl);
+  });
+
+  test('selected mode remains visible and persisted when popup is reopened', async ({
+    extensionContext,
+    fixtureSites,
+    openPopup,
+  }) => {
+    const source = await extensionContext.newPage();
+    const target = await extensionContext.newPage();
+
+    await source.goto(fixtureSites.primary.url('/en/home'));
+    await target.goto(fixtureSites.comparison.url('/ko/home'));
+
+    const firstPopup = await openPopup();
+    await chooseKeepEachTabsWebsiteMode(firstPopup);
+    await firstPopup.close();
+
+    const secondPopup = await openPopup();
+    await expect(
+      secondPopup.getByRole('radio', { name: KEEP_EACH_TABS_WEBSITE_NAME }),
+    ).toBeChecked();
+    await expect(secondPopup.getByText(LANGUAGE_HELPER_COPY)).toBeVisible();
+  });
+});

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -44,3 +44,7 @@ health:
       run: bunx tsc --noEmit
     i18n-validate:
       run: bunx esno scripts/validate-i18n.ts
+    privacy-logging:
+      run: bunx esno scripts/validate-privacy-logging.ts
+    privacy-logging-test:
+      run: bunx vitest run --root . scripts/privacy-logging-rules.test.ts

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "format:fix": "pnpm prettier --write .",
     "typecheck": "pnpm tsc --noEmit",
     "i18n:validate": "esno scripts/validate-i18n.ts",
+    "privacy:logging": "esno scripts/validate-privacy-logging.ts",
+    "privacy:logging:test": "vitest run --root . scripts/privacy-logging-rules.test.ts",
     "cz": "czg"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "clean": "find . -type f -name 'vite.config.*.timestamp-*' -ls -delete 2>/dev/null",
     "health": "lefthook run health",
     "lint:fix": "NODE_OPTIONS='--experimental-strip-types' eslint . --fix --flag unstable_native_nodejs_ts_config",
+    "lint:check": "NODE_OPTIONS='--experimental-strip-types' eslint . --flag unstable_native_nodejs_ts_config --max-warnings=0",
     "format:fix": "pnpm prettier --write .",
     "typecheck": "pnpm tsc --noEmit",
     "i18n:validate": "esno scripts/validate-i18n.ts",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "clean": "find . -type f -name 'vite.config.*.timestamp-*' -ls -delete 2>/dev/null",
     "health": "lefthook run health",
     "lint:fix": "NODE_OPTIONS='--experimental-strip-types' eslint . --fix --flag unstable_native_nodejs_ts_config",
-    "lint:check": "NODE_OPTIONS='--experimental-strip-types' eslint . --flag unstable_native_nodejs_ts_config --max-warnings=0",
+    "lint:check": "NODE_OPTIONS='--experimental-strip-types' eslint src/background src/contentScripts src/popup src/shared src/manifest.ts scripts e2e '*.ts' '*.mts' --flag unstable_native_nodejs_ts_config --max-warnings=0",
     "format:fix": "pnpm prettier --write .",
     "typecheck": "pnpm tsc --noEmit",
     "i18n:validate": "esno scripts/validate-i18n.ts",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "--------------------------------test-----------------------------": "",
     "test": "vitest test",
     "test:e2e": "playwright test",
+    "test:e2e:extension": "playwright test --config playwright.config.extension.ts",
     "test:e2e:landing": "playwright test --config playwright.config.landing.ts",
     "--------------------------------landing-----------------------------": "",
     "dev:landing": "vite --config vite.config.landing.mts",

--- a/playwright.config.extension.ts
+++ b/playwright.config.extension.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e/extension',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [['html', { open: 'never', outputFolder: 'playwright-report-extension' }]],
+  use: {
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+});

--- a/scripts/privacy-logging-rules.test.ts
+++ b/scripts/privacy-logging-rules.test.ts
@@ -108,6 +108,61 @@ describe('privacy logging rules', () => {
     ]);
   });
 
+  it('rejects computed sensitive browser access with identifier keys', () => {
+    expect(
+      messagesFor(`
+        const key = 'href';
+        const prop = 'title';
+        logger.info('x', { raw: window.location[key] });
+        logger.info('x', { raw: document[prop] });
+        logger.info('x', { safe: workflow[key] });
+      `),
+    ).toEqual([
+      'Do not log "raw". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "raw". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+
+  it('keeps outer unsafe alias visible outside inner safe shadowing block', () => {
+    expect(
+      messagesFor(`
+        const meta = { url: window.location.href };
+        if (enabled) {
+          const meta = { tabCount: 2 };
+        }
+        logger.info('x', { meta });
+      `),
+    ).toEqual([
+      'Do not log "url". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+
+  it('keeps outer safe alias isolated from later inner unsafe shadowing block', () => {
+    expect(
+      messagesFor(`
+        const meta = { tabCount: 2 };
+        if (enabled) {
+          const meta = { url: window.location.href };
+        }
+        logger.info('x', { meta });
+      `),
+    ).toEqual([]);
+  });
+
+  it('uses inner alias shadowing inside its block', () => {
+    expect(
+      messagesFor(`
+        const meta = { tabCount: 2 };
+        if (enabled) {
+          const meta = { url: window.location.href };
+          logger.info('x', { meta });
+        }
+      `),
+    ).toEqual([
+      'Do not log "url". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+
   it('rejects raw URL metadata keys', () => {
     expect(
       messagesFor(`

--- a/scripts/privacy-logging-rules.test.ts
+++ b/scripts/privacy-logging-rules.test.ts
@@ -227,4 +227,43 @@ describe('privacy logging rules', () => {
       'Do not log "pageTitle". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
     ]);
   });
+
+  it('allows static primary log messages', () => {
+    expect(
+      messagesFor(`
+        logger.info('URL changed');
+        logger.info(\`URL changed\`);
+      `),
+    ).toEqual([]);
+  });
+
+  it('rejects dynamic primary log message expressions', () => {
+    expect(
+      messagesFor(`
+        const message = \`Navigating \${window.location.href}\`;
+        logger.info(\`Navigating \${window.location.href}\`);
+        logger.info('Navigating ' + tab.url);
+        logger.info(message);
+      `),
+    ).toEqual([
+      'Do not log "href". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "tab". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "href". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+
+  it('rejects nested sensitive member paths inside safe metadata keys', () => {
+    expect(
+      messagesFor(`
+        logger.info('x', { safe: payload.nested.url });
+        logger.info('x', { safe: tab.metadata.title });
+        const nestedUrl = payload.deep.link.url;
+        logger.info('x', { safe: nestedUrl });
+      `),
+    ).toEqual([
+      'Do not log "payload". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "tab". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "payload". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
 });

--- a/scripts/privacy-logging-rules.test.ts
+++ b/scripts/privacy-logging-rules.test.ts
@@ -25,6 +25,14 @@ describe('privacy logging rules', () => {
     ).toEqual([]);
   });
 
+  it('allows non-browser url and title properties', () => {
+    expect(
+      messagesFor(`
+        logger.info('Workflow state', { workflowTitle: workflow.title, apiUrl: api.url });
+      `),
+    ).toEqual([]);
+  });
+
   it('rejects raw URL metadata keys', () => {
     expect(
       messagesFor(`

--- a/scripts/privacy-logging-rules.test.ts
+++ b/scripts/privacy-logging-rules.test.ts
@@ -33,6 +33,26 @@ describe('privacy logging rules', () => {
     ).toEqual([]);
   });
 
+  it('inspects nested metadata object literals recursively', () => {
+    expect(
+      messagesFor(`
+        logger.info('Nested', { meta: { url: window.location.href } });
+        logger.info('Nested payload', { meta: { payload } });
+      `),
+    ).toEqual([
+      'Do not log "url". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "payload". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+
+  it('allows safe nested metadata object literals', () => {
+    expect(
+      messagesFor(`
+        logger.info('Nested safe', { meta: { tabCount: 2, domain: 'example.com' } });
+      `),
+    ).toEqual([]);
+  });
+
   it('rejects raw URL metadata keys', () => {
     expect(
       messagesFor(`

--- a/scripts/privacy-logging-rules.test.ts
+++ b/scripts/privacy-logging-rules.test.ts
@@ -53,6 +53,27 @@ describe('privacy logging rules', () => {
     ).toEqual([]);
   });
 
+  it('inspects nested metadata objects inside arrays and conditional expressions', () => {
+    expect(
+      messagesFor(`
+        logger.info('Nested array', { meta: [{ url: window.location.href }] });
+        logger.info('Nested conditional', { meta: condition ? { url: window.location.href } : { tabCount: 1 } });
+      `),
+    ).toEqual([
+      'Do not log "url". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "url". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+
+  it('allows safe nested arrays and conditional metadata', () => {
+    expect(
+      messagesFor(`
+        logger.info('Safe array', { meta: [{ tabCount: 2, domain: 'example.com', enabled: true }] });
+        logger.info('Safe conditional', { meta: condition ? { tabCount: 1, enabled: true } : { domain: 'example.com' } });
+      `),
+    ).toEqual([]);
+  });
+
   it('rejects raw URL metadata keys', () => {
     expect(
       messagesFor(`

--- a/scripts/privacy-logging-rules.test.ts
+++ b/scripts/privacy-logging-rules.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { analyzePrivacyLoggingSource } from './privacy-logging-rules';
+
+function messagesFor(sourceText: string): Array<string> {
+  return analyzePrivacyLoggingSource('src/example.ts', sourceText).map(
+    (violation) => violation.message,
+  );
+}
+
+describe('privacy logging rules', () => {
+  it('allows ids, modes, reasons, booleans, counts, and sanitized domains', () => {
+    expect(
+      messagesFor(`
+        logger.info('Relaying URL sync mode change', {
+          sourceTabId,
+          targetTabId,
+          mode,
+          reason: 'user-change',
+          enabled: true,
+          tabCount: 2,
+          domain: 'example.com',
+        });
+      `),
+    ).toEqual([]);
+  });
+
+  it('rejects raw URL metadata keys', () => {
+    expect(
+      messagesFor(`
+        logger.info('URL changed', { url: window.location.href });
+        logger.debug('Relaying URL sync message', { sourceUrl, targetUrl, normalizedUrl });
+      `),
+    ).toEqual([
+      'Do not log "url". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "sourceUrl". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "targetUrl". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "normalizedUrl". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+
+  it('rejects shorthand payload-like metadata', () => {
+    expect(
+      messagesFor(`
+        logger.debug('Received message', { payload });
+        logger.debug('Relaying scroll sync message', { data, sender });
+        logger.error('Invalid acknowledgment', { response });
+      `),
+    ).toEqual([
+      'Do not log "payload". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "data". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "sender". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "response". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+
+  it('rejects direct browser URL and title expressions', () => {
+    expect(
+      messagesFor(`
+        logger.info('Processing tab', { tabId: tab.id, currentUrl: tab.url });
+        logger.info('Page metadata', { pageTitle: document.title });
+      `),
+    ).toEqual([
+      'Do not log "currentUrl". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "pageTitle". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+});

--- a/scripts/privacy-logging-rules.test.ts
+++ b/scripts/privacy-logging-rules.test.ts
@@ -33,6 +33,26 @@ describe('privacy logging rules', () => {
     ).toEqual([]);
   });
 
+  it('inspects simple same-file metadata aliases', () => {
+    expect(
+      messagesFor(`
+        const meta = { url: window.location.href };
+        logger.info('x', { meta });
+      `),
+    ).toEqual([
+      'Do not log "url". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+
+  it('allows safe simple same-file metadata aliases', () => {
+    expect(
+      messagesFor(`
+        const meta = { tabCount: 2, domain: 'example.com' };
+        logger.info('x', { meta });
+      `),
+    ).toEqual([]);
+  });
+
   it('inspects nested metadata object literals recursively', () => {
     expect(
       messagesFor(`
@@ -72,6 +92,20 @@ describe('privacy logging rules', () => {
         logger.info('Safe conditional', { meta: condition ? { tabCount: 1, enabled: true } : { domain: 'example.com' } });
       `),
     ).toEqual([]);
+  });
+
+  it('rejects bracket-notation browser data inside safe metadata keys', () => {
+    expect(
+      messagesFor(`
+        logger.info('x', { meta: { raw: window.location['href'] } });
+        logger.info('x', { meta: { raw: document['title'] } });
+        logger.info('x', { meta: { raw: window['location'].href } });
+      `),
+    ).toEqual([
+      'Do not log "href". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "title". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "href". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
   });
 
   it('rejects raw URL metadata keys', () => {

--- a/scripts/privacy-logging-rules.test.ts
+++ b/scripts/privacy-logging-rules.test.ts
@@ -163,6 +163,30 @@ describe('privacy logging rules', () => {
     ]);
   });
 
+  it('treats parameter bindings as shadowing outer unsafe aliases', () => {
+    expect(
+      messagesFor(`
+        const meta = { url: window.location.href };
+        function run(meta) {
+          logger.info('x', { meta });
+        }
+      `),
+    ).toEqual([]);
+  });
+
+  it('treats catch bindings as shadowing outer unsafe aliases', () => {
+    expect(
+      messagesFor(`
+        const meta = { url: window.location.href };
+        try {
+          throw new Error('x');
+        } catch (meta) {
+          logger.info('x', { meta });
+        }
+      `),
+    ).toEqual([]);
+  });
+
   it('rejects raw URL metadata keys', () => {
     expect(
       messagesFor(`

--- a/scripts/privacy-logging-rules.test.ts
+++ b/scripts/privacy-logging-rules.test.ts
@@ -266,4 +266,31 @@ describe('privacy logging rules', () => {
       'Do not log "payload". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
     ]);
   });
+
+  it('rejects logger.with calls and aliases derived from logger.with', () => {
+    expect(
+      messagesFor(`
+        logger.with({ tabId }).info('x', { payload });
+        const scopedLogger = logger.with({ tabId });
+        scopedLogger.warn('x', { safe: window.location.href });
+      `),
+    ).toEqual([
+      'Do not log "payload". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "href". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
+
+  it('rejects nested raw object members under sensitive roots', () => {
+    expect(
+      messagesFor(`
+        logger.info('x', { safe: payload.response });
+        logger.info('x', { safe: response.payload });
+        logger.info('x', { safe: syncState.tab });
+      `),
+    ).toEqual([
+      'Do not log "payload". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "response". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+      'Do not log "syncState". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.',
+    ]);
+  });
 });

--- a/scripts/privacy-logging-rules.ts
+++ b/scripts/privacy-logging-rules.ts
@@ -77,6 +77,18 @@ export function analyzePrivacyLoggingSource(
     if (unsafeName) {
       report(expression, unsafeName);
     }
+
+    if (ts.isIdentifier(expression) || ts.isPropertyAccessExpression(expression)) {
+      return;
+    }
+
+    expression.forEachChild((child) => {
+      if (!ts.isExpression(child)) {
+        return;
+      }
+
+      inspectExpression(child);
+    });
   }
 
   function inspectObjectLiteral(expression: ts.ObjectLiteralExpression): void {

--- a/scripts/privacy-logging-rules.ts
+++ b/scripts/privacy-logging-rules.ts
@@ -67,6 +67,11 @@ export function analyzePrivacyLoggingSource(
   }
 
   function inspectExpression(expression: ts.Expression): void {
+    if (ts.isObjectLiteralExpression(expression)) {
+      inspectObjectLiteral(expression);
+      return;
+    }
+
     const unsafeName = findUnsafeExpressionName(expression);
 
     if (unsafeName) {

--- a/scripts/privacy-logging-rules.ts
+++ b/scripts/privacy-logging-rules.ts
@@ -186,7 +186,7 @@ export function analyzePrivacyLoggingSource(
   }
 
   function visit(node: ts.Node): void {
-    if (ts.isCallExpression(node) && isLoggerCall(node)) {
+    if (ts.isCallExpression(node) && isLoggerCall(node, bindings)) {
       const [messageArgument, ...metadataArguments] = node.arguments;
 
       if (messageArgument && shouldInspectPrimaryLogArgument(messageArgument)) {
@@ -231,16 +231,52 @@ function getScriptKind(filePath: string): ts.ScriptKind {
   return ts.ScriptKind.TS;
 }
 
-function isLoggerCall(node: ts.CallExpression): boolean {
+function isLoggerCall(
+  node: ts.CallExpression,
+  bindings: Map<string, Array<BindingEntry>>,
+): boolean {
   if (!ts.isPropertyAccessExpression(node.expression)) {
     return false;
   }
 
   return (
-    ts.isIdentifier(node.expression.expression) &&
-    node.expression.expression.text === 'logger' &&
-    LOGGER_METHODS.has(node.expression.name.text)
+    LOGGER_METHODS.has(node.expression.name.text) &&
+    isLoggerExpression(node.expression.expression, bindings)
   );
+}
+
+function isLoggerExpression(
+  expression: ts.Expression,
+  bindings: Map<string, Array<BindingEntry>>,
+  seenAliases = new Set<string>(),
+): boolean {
+  if (ts.isIdentifier(expression)) {
+    if (expression.text === 'logger') {
+      return true;
+    }
+
+    if (seenAliases.has(expression.text)) {
+      return false;
+    }
+
+    const initializer = resolveVisibleInitializer(bindings, expression);
+    if (!initializer) {
+      return false;
+    }
+
+    const nextSeenAliases = new Set(seenAliases);
+    nextSeenAliases.add(expression.text);
+    return isLoggerExpression(initializer, bindings, nextSeenAliases);
+  }
+
+  if (ts.isCallExpression(expression) && ts.isPropertyAccessExpression(expression.expression)) {
+    return (
+      expression.expression.name.text === 'with' &&
+      isLoggerExpression(expression.expression.expression, bindings, seenAliases)
+    );
+  }
+
+  return false;
 }
 
 function getPropertyNameText(name: ts.PropertyName): string | null {
@@ -335,7 +371,11 @@ function findSensitiveRootName(
     return null;
   }
 
-  if (nestedNames.some((name) => SENSITIVE_MEMBER_SUFFIXES.has(name))) {
+  if (
+    nestedNames.some(
+      (name) => SENSITIVE_MEMBER_SUFFIXES.has(name) || DISALLOWED_LOG_NAMES.has(name),
+    )
+  ) {
     return rootName;
   }
 

--- a/scripts/privacy-logging-rules.ts
+++ b/scripts/privacy-logging-rules.ts
@@ -25,16 +25,6 @@ const DISALLOWED_LOG_NAMES = new Set([
   'url',
 ]);
 
-const SENSITIVE_ROOT_IDENTIFIERS = new Set([
-  'data',
-  'metadata',
-  'payload',
-  'response',
-  'sender',
-  'syncState',
-  'tab',
-]);
-
 export interface PrivacyLoggingViolation {
   filePath: string;
   line: number;
@@ -230,14 +220,16 @@ function findSensitiveRootName(expression: ts.PropertyAccessExpression): string 
     return null;
   }
 
-  const [rootName] = names;
-  const lastName = names[names.length - 1];
+  if (matchesPropertyAccessPath(names, ['payload', 'url'])) {
+    return names[0];
+  }
 
-  if (
-    SENSITIVE_ROOT_IDENTIFIERS.has(rootName) &&
-    (DISALLOWED_LOG_NAMES.has(lastName) || lastName === 'href')
-  ) {
-    return rootName;
+  if (matchesPropertyAccessPath(names, ['tab', 'url'])) {
+    return names[0];
+  }
+
+  if (matchesPropertyAccessPath(names, ['tab', 'title'])) {
+    return names[0];
   }
 
   return null;
@@ -250,17 +242,27 @@ function findDirectBrowserDataName(expression: ts.PropertyAccessExpression): str
     return null;
   }
 
-  const lastName = names[names.length - 1];
-
-  if (lastName === 'url' || lastName === 'title') {
-    return lastName;
+  if (matchesPropertyAccessPath(names, ['document', 'title'])) {
+    return names[names.length - 1];
   }
 
-  if (lastName === 'href' && names.includes('location')) {
-    return lastName;
+  if (matchesPropertyAccessPath(names, ['location', 'href'])) {
+    return names[names.length - 1];
+  }
+
+  if (matchesPropertyAccessPath(names, ['window', 'location', 'href'])) {
+    return names[names.length - 1];
   }
 
   return null;
+}
+
+function matchesPropertyAccessPath(names: Array<string>, expectedPath: Array<string>): boolean {
+  if (names.length !== expectedPath.length) {
+    return false;
+  }
+
+  return expectedPath.every((part, index) => names[index] === part);
 }
 
 function getPropertyAccessNames(expression: ts.PropertyAccessExpression): Array<string> | null {

--- a/scripts/privacy-logging-rules.ts
+++ b/scripts/privacy-logging-rules.ts
@@ -46,6 +46,7 @@ export function analyzePrivacyLoggingSource(
 
   const violations: Array<PrivacyLoggingViolation> = [];
   const seenViolations = new Set<string>();
+  const variableInitializers = collectVariableInitializers(sourceFile);
 
   function report(node: ts.Node, name: string): void {
     const start = node.getStart(sourceFile);
@@ -66,7 +67,7 @@ export function analyzePrivacyLoggingSource(
     });
   }
 
-  function inspectExpression(expression: ts.Expression): void {
+  function inspectExpression(expression: ts.Expression, seenAliases = new Set<string>()): void {
     if (ts.isObjectLiteralExpression(expression)) {
       inspectObjectLiteral(expression);
       return;
@@ -78,7 +79,20 @@ export function analyzePrivacyLoggingSource(
       report(expression, unsafeName);
     }
 
-    if (ts.isIdentifier(expression) || ts.isPropertyAccessExpression(expression)) {
+    if (ts.isIdentifier(expression)) {
+      const initializer = variableInitializers.get(expression.text);
+
+      if (!initializer || seenAliases.has(expression.text)) {
+        return;
+      }
+
+      const nextSeenAliases = new Set(seenAliases);
+      nextSeenAliases.add(expression.text);
+      inspectExpression(initializer, nextSeenAliases);
+      return;
+    }
+
+    if (isMemberAccessExpression(expression)) {
       return;
     }
 
@@ -87,7 +101,7 @@ export function analyzePrivacyLoggingSource(
         return;
       }
 
-      inspectExpression(child);
+      inspectExpression(child, seenAliases);
     });
   }
 
@@ -96,8 +110,10 @@ export function analyzePrivacyLoggingSource(
       if (ts.isShorthandPropertyAssignment(property)) {
         if (DISALLOWED_LOG_NAMES.has(property.name.text)) {
           report(property.name, property.name.text);
+          continue;
         }
 
+        inspectExpression(property.name);
         continue;
       }
 
@@ -189,7 +205,7 @@ function findUnsafeExpressionName(expression: ts.Expression): string | null {
     return DISALLOWED_LOG_NAMES.has(expression.text) ? expression.text : null;
   }
 
-  if (ts.isPropertyAccessExpression(expression)) {
+  if (isMemberAccessExpression(expression)) {
     const rootSensitiveName = findSensitiveRootName(expression);
 
     if (rootSensitiveName) {
@@ -230,8 +246,10 @@ function findUnsafeExpressionName(expression: ts.Expression): string | null {
   return nestedUnsafeName;
 }
 
-function findSensitiveRootName(expression: ts.PropertyAccessExpression): string | null {
-  const names = getPropertyAccessNames(expression);
+function findSensitiveRootName(
+  expression: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+): string | null {
+  const names = getMemberAccessNames(expression);
 
   if (!names || names.length < 2) {
     return null;
@@ -252,8 +270,10 @@ function findSensitiveRootName(expression: ts.PropertyAccessExpression): string 
   return null;
 }
 
-function findDirectBrowserDataName(expression: ts.PropertyAccessExpression): string | null {
-  const names = getPropertyAccessNames(expression);
+function findDirectBrowserDataName(
+  expression: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+): string | null {
+  const names = getMemberAccessNames(expression);
 
   if (!names) {
     return null;
@@ -282,12 +302,32 @@ function matchesPropertyAccessPath(names: Array<string>, expectedPath: Array<str
   return expectedPath.every((part, index) => names[index] === part);
 }
 
-function getPropertyAccessNames(expression: ts.PropertyAccessExpression): Array<string> | null {
+function isMemberAccessExpression(
+  expression: ts.Expression,
+): expression is ts.PropertyAccessExpression | ts.ElementAccessExpression {
+  return ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression);
+}
+
+function getMemberAccessNames(
+  expression: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+): Array<string> | null {
   const names = new Array<string>();
   let current: ts.Expression = expression;
 
-  while (ts.isPropertyAccessExpression(current)) {
-    names.unshift(current.name.text);
+  while (isMemberAccessExpression(current)) {
+    if (ts.isPropertyAccessExpression(current)) {
+      names.unshift(current.name.text);
+      current = current.expression;
+      continue;
+    }
+
+    const argumentName = getElementAccessArgumentName(current.argumentExpression);
+
+    if (!argumentName) {
+      return null;
+    }
+
+    names.unshift(argumentName);
     current = current.expression;
   }
 
@@ -298,4 +338,28 @@ function getPropertyAccessNames(expression: ts.PropertyAccessExpression): Array<
   names.unshift(current.text);
 
   return names;
+}
+
+function getElementAccessArgumentName(argument: ts.Expression): string | null {
+  if (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument)) {
+    return argument.text;
+  }
+
+  return null;
+}
+
+function collectVariableInitializers(sourceFile: ts.SourceFile): Map<string, ts.Expression> {
+  const initializers = new Map<string, ts.Expression>();
+
+  function visit(node: ts.Node): void {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      initializers.set(node.name.text, node.initializer);
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  return initializers;
 }

--- a/scripts/privacy-logging-rules.ts
+++ b/scripts/privacy-logging-rules.ts
@@ -1,6 +1,30 @@
 import * as ts from 'typescript';
 
 const LOGGER_METHODS = new Set(['debug', 'error', 'info', 'warn']);
+const SENSITIVE_MEMBER_SUFFIXES = new Set([
+  'alternateUrl',
+  'alternateUrls',
+  'canonicalUrl',
+  'currentUrl',
+  'documentTitle',
+  'href',
+  'normalizedUrl',
+  'pageTitle',
+  'sourceUrl',
+  'tabTitle',
+  'targetUrl',
+  'title',
+  'url',
+]);
+const SENSITIVE_MEMBER_ROOTS = new Set([
+  'data',
+  'metadata',
+  'payload',
+  'response',
+  'sender',
+  'syncState',
+  'tab',
+]);
 
 const DISALLOWED_LOG_NAMES = new Set([
   'alternateUrl',
@@ -91,7 +115,7 @@ export function analyzePrivacyLoggingSource(
 
     const unsafeMatch = findUnsafeExpressionMatch(expression);
 
-    if (unsafeMatch) {
+    if (unsafeMatch && (ts.isIdentifier(expression) || isMemberAccessExpression(expression))) {
       report(
         expression,
         unsafeMatch.prefersContainerName && containerName ? containerName : unsafeMatch.name,
@@ -112,6 +136,13 @@ export function analyzePrivacyLoggingSource(
     }
 
     if (isMemberAccessExpression(expression)) {
+      return;
+    }
+
+    if (ts.isTemplateExpression(expression)) {
+      for (const span of expression.templateSpans) {
+        inspectExpression(span.expression, seenAliases, containerName);
+      }
       return;
     }
 
@@ -156,7 +187,13 @@ export function analyzePrivacyLoggingSource(
 
   function visit(node: ts.Node): void {
     if (ts.isCallExpression(node) && isLoggerCall(node)) {
-      for (const argument of node.arguments.slice(1)) {
+      const [messageArgument, ...metadataArguments] = node.arguments;
+
+      if (messageArgument && shouldInspectPrimaryLogArgument(messageArgument)) {
+        inspectExpression(messageArgument);
+      }
+
+      for (const argument of metadataArguments) {
         if (ts.isObjectLiteralExpression(argument)) {
           inspectObjectLiteral(argument);
           continue;
@@ -293,16 +330,13 @@ function findSensitiveRootName(
     return null;
   }
 
-  if (matchesPropertyAccessPath(names, ['payload', 'url'])) {
-    return names[0];
+  const [rootName, ...nestedNames] = names;
+  if (!rootName || !SENSITIVE_MEMBER_ROOTS.has(rootName)) {
+    return null;
   }
 
-  if (matchesPropertyAccessPath(names, ['tab', 'url'])) {
-    return names[0];
-  }
-
-  if (matchesPropertyAccessPath(names, ['tab', 'title'])) {
-    return names[0];
+  if (nestedNames.some((name) => SENSITIVE_MEMBER_SUFFIXES.has(name))) {
+    return rootName;
   }
 
   return null;
@@ -410,6 +444,10 @@ function getElementAccessArgumentName(argument: ts.Expression): string | null {
   }
 
   return null;
+}
+
+function shouldInspectPrimaryLogArgument(argument: ts.Expression): boolean {
+  return !ts.isStringLiteral(argument) && !ts.isNoSubstitutionTemplateLiteral(argument);
 }
 
 function collectBindings(sourceFile: ts.SourceFile): Map<string, Array<BindingEntry>> {

--- a/scripts/privacy-logging-rules.ts
+++ b/scripts/privacy-logging-rules.ts
@@ -1,0 +1,282 @@
+import * as ts from 'typescript';
+
+const LOGGER_METHODS = new Set(['debug', 'error', 'info', 'warn']);
+
+const DISALLOWED_LOG_NAMES = new Set([
+  'alternateUrl',
+  'alternateUrls',
+  'canonicalUrl',
+  'currentUrl',
+  'data',
+  'documentTitle',
+  'href',
+  'metadata',
+  'normalizedUrl',
+  'pageTitle',
+  'payload',
+  'response',
+  'sender',
+  'sourceUrl',
+  'syncState',
+  'tab',
+  'tabTitle',
+  'targetUrl',
+  'title',
+  'url',
+]);
+
+const SENSITIVE_ROOT_IDENTIFIERS = new Set([
+  'data',
+  'metadata',
+  'payload',
+  'response',
+  'sender',
+  'syncState',
+  'tab',
+]);
+
+export interface PrivacyLoggingViolation {
+  filePath: string;
+  line: number;
+  column: number;
+  message: string;
+}
+
+export function analyzePrivacyLoggingSource(
+  filePath: string,
+  sourceText: string,
+): Array<PrivacyLoggingViolation> {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    getScriptKind(filePath),
+  );
+
+  const violations: Array<PrivacyLoggingViolation> = [];
+  const seenViolations = new Set<string>();
+
+  function report(node: ts.Node, name: string): void {
+    const start = node.getStart(sourceFile);
+    const key = `${start}:${name}`;
+
+    if (seenViolations.has(key)) {
+      return;
+    }
+
+    seenViolations.add(key);
+
+    const position = sourceFile.getLineAndCharacterOfPosition(start);
+    violations.push({
+      filePath,
+      line: position.line + 1,
+      column: position.character + 1,
+      message: `Do not log "${name}". Log tabId, mode, reason, counts, booleans, or sanitized domain instead.`,
+    });
+  }
+
+  function inspectExpression(expression: ts.Expression): void {
+    const unsafeName = findUnsafeExpressionName(expression);
+
+    if (unsafeName) {
+      report(expression, unsafeName);
+    }
+  }
+
+  function inspectObjectLiteral(expression: ts.ObjectLiteralExpression): void {
+    for (const property of expression.properties) {
+      if (ts.isShorthandPropertyAssignment(property)) {
+        if (DISALLOWED_LOG_NAMES.has(property.name.text)) {
+          report(property.name, property.name.text);
+        }
+
+        continue;
+      }
+
+      if (ts.isPropertyAssignment(property)) {
+        const propertyName = getPropertyNameText(property.name);
+
+        if (propertyName && DISALLOWED_LOG_NAMES.has(propertyName)) {
+          report(property.name, propertyName);
+          continue;
+        }
+
+        inspectExpression(property.initializer);
+        continue;
+      }
+
+      if (ts.isSpreadAssignment(property)) {
+        inspectExpression(property.expression);
+      }
+    }
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node) && isLoggerCall(node)) {
+      for (const argument of node.arguments.slice(1)) {
+        if (ts.isObjectLiteralExpression(argument)) {
+          inspectObjectLiteral(argument);
+          continue;
+        }
+
+        inspectExpression(argument);
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  return violations;
+}
+
+export function formatPrivacyLoggingViolation(violation: PrivacyLoggingViolation): string {
+  return `${violation.filePath}:${violation.line}:${violation.column} ${violation.message}`;
+}
+
+function getScriptKind(filePath: string): ts.ScriptKind {
+  if (filePath.endsWith('.tsx')) {
+    return ts.ScriptKind.TSX;
+  }
+
+  if (filePath.endsWith('.jsx')) {
+    return ts.ScriptKind.JSX;
+  }
+
+  if (filePath.endsWith('.js')) {
+    return ts.ScriptKind.JS;
+  }
+
+  return ts.ScriptKind.TS;
+}
+
+function isLoggerCall(node: ts.CallExpression): boolean {
+  if (!ts.isPropertyAccessExpression(node.expression)) {
+    return false;
+  }
+
+  return (
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === 'logger' &&
+    LOGGER_METHODS.has(node.expression.name.text)
+  );
+}
+
+function getPropertyNameText(name: ts.PropertyName): string | null {
+  if (
+    ts.isIdentifier(name) ||
+    ts.isStringLiteral(name) ||
+    ts.isNoSubstitutionTemplateLiteral(name) ||
+    ts.isNumericLiteral(name)
+  ) {
+    return name.text;
+  }
+
+  return null;
+}
+
+function findUnsafeExpressionName(expression: ts.Expression): string | null {
+  if (ts.isIdentifier(expression)) {
+    return DISALLOWED_LOG_NAMES.has(expression.text) ? expression.text : null;
+  }
+
+  if (ts.isPropertyAccessExpression(expression)) {
+    const rootSensitiveName = findSensitiveRootName(expression);
+
+    if (rootSensitiveName) {
+      return rootSensitiveName;
+    }
+
+    const expressionName = findDirectBrowserDataName(expression);
+
+    if (expressionName) {
+      return expressionName;
+    }
+
+    return null;
+  }
+
+  if (ts.isElementAccessExpression(expression)) {
+    const targetName = findUnsafeExpressionName(expression.expression);
+
+    if (targetName) {
+      return targetName;
+    }
+
+    if (ts.isExpression(expression.argumentExpression)) {
+      return findUnsafeExpressionName(expression.argumentExpression);
+    }
+  }
+
+  let nestedUnsafeName: string | null = null;
+
+  expression.forEachChild((child) => {
+    if (nestedUnsafeName || !ts.isExpression(child)) {
+      return;
+    }
+
+    nestedUnsafeName = findUnsafeExpressionName(child);
+  });
+
+  return nestedUnsafeName;
+}
+
+function findSensitiveRootName(expression: ts.PropertyAccessExpression): string | null {
+  const names = getPropertyAccessNames(expression);
+
+  if (!names || names.length < 2) {
+    return null;
+  }
+
+  const [rootName] = names;
+  const lastName = names[names.length - 1];
+
+  if (
+    SENSITIVE_ROOT_IDENTIFIERS.has(rootName) &&
+    (DISALLOWED_LOG_NAMES.has(lastName) || lastName === 'href')
+  ) {
+    return rootName;
+  }
+
+  return null;
+}
+
+function findDirectBrowserDataName(expression: ts.PropertyAccessExpression): string | null {
+  const names = getPropertyAccessNames(expression);
+
+  if (!names) {
+    return null;
+  }
+
+  const lastName = names[names.length - 1];
+
+  if (lastName === 'url' || lastName === 'title') {
+    return lastName;
+  }
+
+  if (lastName === 'href' && names.includes('location')) {
+    return lastName;
+  }
+
+  return null;
+}
+
+function getPropertyAccessNames(expression: ts.PropertyAccessExpression): Array<string> | null {
+  const names = new Array<string>();
+  let current: ts.Expression = expression;
+
+  while (ts.isPropertyAccessExpression(current)) {
+    names.unshift(current.name.text);
+    current = current.expression;
+  }
+
+  if (!ts.isIdentifier(current)) {
+    return null;
+  }
+
+  names.unshift(current.text);
+
+  return names;
+}

--- a/scripts/privacy-logging-rules.ts
+++ b/scripts/privacy-logging-rules.ts
@@ -37,9 +37,9 @@ interface UnsafeExpressionMatch {
   prefersContainerName: boolean;
 }
 
-interface VariableInitializerEntry {
+interface BindingEntry {
   name: string;
-  initializer: ts.Expression;
+  initializer?: ts.Expression;
   declarationStart: number;
   scopeNode: ts.Node;
 }
@@ -58,7 +58,7 @@ export function analyzePrivacyLoggingSource(
 
   const violations: Array<PrivacyLoggingViolation> = [];
   const seenViolations = new Set<string>();
-  const variableInitializers = collectVariableInitializers(sourceFile);
+  const bindings = collectBindings(sourceFile);
 
   function report(node: ts.Node, name: string): void {
     const start = node.getStart(sourceFile);
@@ -99,7 +99,7 @@ export function analyzePrivacyLoggingSource(
     }
 
     if (ts.isIdentifier(expression)) {
-      const initializer = resolveVisibleInitializer(variableInitializers, expression);
+      const initializer = resolveVisibleInitializer(bindings, expression);
 
       if (!initializer || seenAliases.has(expression.text)) {
         return;
@@ -412,21 +412,44 @@ function getElementAccessArgumentName(argument: ts.Expression): string | null {
   return null;
 }
 
-function collectVariableInitializers(
-  sourceFile: ts.SourceFile,
-): Map<string, Array<VariableInitializerEntry>> {
-  const initializers = new Map<string, Array<VariableInitializerEntry>>();
+function collectBindings(sourceFile: ts.SourceFile): Map<string, Array<BindingEntry>> {
+  const bindings = new Map<string, Array<BindingEntry>>();
 
   function visit(node: ts.Node): void {
     if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
-      const entries = initializers.get(node.name.text) ?? [];
+      const entries = bindings.get(node.name.text) ?? [];
       entries.push({
         name: node.name.text,
         initializer: node.initializer,
         declarationStart: node.getStart(sourceFile),
         scopeNode: getDeclarationScopeNode(node),
       });
-      initializers.set(node.name.text, entries);
+      bindings.set(node.name.text, entries);
+    }
+
+    if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+      const entries = bindings.get(node.name.text) ?? [];
+      entries.push({
+        name: node.name.text,
+        declarationStart: node.getStart(sourceFile),
+        scopeNode: getParameterScopeNode(node),
+      });
+      bindings.set(node.name.text, entries);
+    }
+
+    if (
+      ts.isCatchClause(node) &&
+      node.variableDeclaration &&
+      ts.isIdentifier(node.variableDeclaration.name)
+    ) {
+      const name = node.variableDeclaration.name.text;
+      const entries = bindings.get(name) ?? [];
+      entries.push({
+        name,
+        declarationStart: node.variableDeclaration.getStart(sourceFile),
+        scopeNode: node,
+      });
+      bindings.set(name, entries);
     }
 
     ts.forEachChild(node, visit);
@@ -434,14 +457,14 @@ function collectVariableInitializers(
 
   visit(sourceFile);
 
-  return initializers;
+  return bindings;
 }
 
 function resolveVisibleInitializer(
-  initializers: Map<string, Array<VariableInitializerEntry>>,
+  bindings: Map<string, Array<BindingEntry>>,
   identifier: ts.Identifier,
 ): ts.Expression | null {
-  const candidates = initializers.get(identifier.text);
+  const candidates = bindings.get(identifier.text);
 
   if (!candidates) {
     return null;
@@ -449,7 +472,7 @@ function resolveVisibleInitializer(
 
   const usageStart = identifier.getStart();
   const usageScopes = getContainingScopes(identifier);
-  let bestCandidate: VariableInitializerEntry | null = null;
+  let bestCandidate: BindingEntry | null = null;
   let bestDistance = Number.POSITIVE_INFINITY;
 
   for (const candidate of candidates) {
@@ -473,7 +496,11 @@ function resolveVisibleInitializer(
     }
   }
 
-  return bestCandidate?.initializer ?? null;
+  if (!bestCandidate || !bestCandidate.initializer) {
+    return null;
+  }
+
+  return bestCandidate.initializer;
 }
 
 function getContainingScopes(node: ts.Node): Array<ts.Node> {
@@ -514,13 +541,31 @@ function getDeclarationScopeNode(node: ts.VariableDeclaration): ts.Node {
   return node.getSourceFile();
 }
 
+function getParameterScopeNode(node: ts.ParameterDeclaration): ts.Node {
+  let current: ts.Node | undefined = node.parent;
+
+  while (current) {
+    if (ts.isFunctionLike(current) || ts.isSourceFile(current)) {
+      return current;
+    }
+
+    current = current.parent;
+  }
+
+  return node.getSourceFile();
+}
+
 function isScopeNode(node: ts.Node): boolean {
   return isBlockScopeNode(node) || isVarScopeNode(node);
 }
 
 function isBlockScopeNode(node: ts.Node): boolean {
   return (
-    ts.isSourceFile(node) || ts.isBlock(node) || ts.isCaseClause(node) || ts.isDefaultClause(node)
+    ts.isSourceFile(node) ||
+    ts.isBlock(node) ||
+    ts.isCaseClause(node) ||
+    ts.isDefaultClause(node) ||
+    ts.isCatchClause(node)
   );
 }
 

--- a/scripts/privacy-logging-rules.ts
+++ b/scripts/privacy-logging-rules.ts
@@ -32,6 +32,18 @@ export interface PrivacyLoggingViolation {
   message: string;
 }
 
+interface UnsafeExpressionMatch {
+  name: string;
+  prefersContainerName: boolean;
+}
+
+interface VariableInitializerEntry {
+  name: string;
+  initializer: ts.Expression;
+  declarationStart: number;
+  scopeNode: ts.Node;
+}
+
 export function analyzePrivacyLoggingSource(
   filePath: string,
   sourceText: string,
@@ -67,20 +79,27 @@ export function analyzePrivacyLoggingSource(
     });
   }
 
-  function inspectExpression(expression: ts.Expression, seenAliases = new Set<string>()): void {
+  function inspectExpression(
+    expression: ts.Expression,
+    seenAliases = new Set<string>(),
+    containerName?: string,
+  ): void {
     if (ts.isObjectLiteralExpression(expression)) {
       inspectObjectLiteral(expression);
       return;
     }
 
-    const unsafeName = findUnsafeExpressionName(expression);
+    const unsafeMatch = findUnsafeExpressionMatch(expression);
 
-    if (unsafeName) {
-      report(expression, unsafeName);
+    if (unsafeMatch) {
+      report(
+        expression,
+        unsafeMatch.prefersContainerName && containerName ? containerName : unsafeMatch.name,
+      );
     }
 
     if (ts.isIdentifier(expression)) {
-      const initializer = variableInitializers.get(expression.text);
+      const initializer = resolveVisibleInitializer(variableInitializers, expression);
 
       if (!initializer || seenAliases.has(expression.text)) {
         return;
@@ -88,7 +107,7 @@ export function analyzePrivacyLoggingSource(
 
       const nextSeenAliases = new Set(seenAliases);
       nextSeenAliases.add(expression.text);
-      inspectExpression(initializer, nextSeenAliases);
+      inspectExpression(initializer, nextSeenAliases, containerName);
       return;
     }
 
@@ -101,7 +120,7 @@ export function analyzePrivacyLoggingSource(
         return;
       }
 
-      inspectExpression(child, seenAliases);
+      inspectExpression(child, seenAliases, containerName);
     });
   }
 
@@ -113,7 +132,7 @@ export function analyzePrivacyLoggingSource(
           continue;
         }
 
-        inspectExpression(property.name);
+        inspectExpression(property.name, new Set<string>(), property.name.text);
         continue;
       }
 
@@ -125,7 +144,7 @@ export function analyzePrivacyLoggingSource(
           continue;
         }
 
-        inspectExpression(property.initializer);
+        inspectExpression(property.initializer, new Set<string>(), propertyName ?? undefined);
         continue;
       }
 
@@ -200,47 +219,65 @@ function getPropertyNameText(name: ts.PropertyName): string | null {
   return null;
 }
 
-function findUnsafeExpressionName(expression: ts.Expression): string | null {
+function findUnsafeExpressionMatch(expression: ts.Expression): UnsafeExpressionMatch | null {
   if (ts.isIdentifier(expression)) {
-    return DISALLOWED_LOG_NAMES.has(expression.text) ? expression.text : null;
+    return DISALLOWED_LOG_NAMES.has(expression.text)
+      ? {
+          name: expression.text,
+          prefersContainerName: false,
+        }
+      : null;
   }
 
   if (isMemberAccessExpression(expression)) {
     const rootSensitiveName = findSensitiveRootName(expression);
 
     if (rootSensitiveName) {
-      return rootSensitiveName;
+      return {
+        name: rootSensitiveName,
+        prefersContainerName: false,
+      };
     }
 
     const expressionName = findDirectBrowserDataName(expression);
 
     if (expressionName) {
-      return expressionName;
+      return {
+        name: expressionName,
+        prefersContainerName: false,
+      };
+    }
+
+    if (isComputedSensitiveAccess(expression)) {
+      return {
+        name: 'computed browser access',
+        prefersContainerName: true,
+      };
     }
 
     return null;
   }
 
   if (ts.isElementAccessExpression(expression)) {
-    const targetName = findUnsafeExpressionName(expression.expression);
+    const targetName = findUnsafeExpressionMatch(expression.expression);
 
     if (targetName) {
       return targetName;
     }
 
     if (ts.isExpression(expression.argumentExpression)) {
-      return findUnsafeExpressionName(expression.argumentExpression);
+      return findUnsafeExpressionMatch(expression.argumentExpression);
     }
   }
 
-  let nestedUnsafeName: string | null = null;
+  let nestedUnsafeName: UnsafeExpressionMatch | null = null;
 
   expression.forEachChild((child) => {
     if (nestedUnsafeName || !ts.isExpression(child)) {
       return;
     }
 
-    nestedUnsafeName = findUnsafeExpressionName(child);
+    nestedUnsafeName = findUnsafeExpressionMatch(child);
   });
 
   return nestedUnsafeName;
@@ -249,9 +286,10 @@ function findUnsafeExpressionName(expression: ts.Expression): string | null {
 function findSensitiveRootName(
   expression: ts.PropertyAccessExpression | ts.ElementAccessExpression,
 ): string | null {
-  const names = getMemberAccessNames(expression);
+  const pathInfo = getMemberAccessPathInfo(expression);
+  const names = pathInfo?.names;
 
-  if (!names || names.length < 2) {
+  if (!names || names.length < 2 || pathInfo.hasComputedNonLiteral) {
     return null;
   }
 
@@ -273,9 +311,10 @@ function findSensitiveRootName(
 function findDirectBrowserDataName(
   expression: ts.PropertyAccessExpression | ts.ElementAccessExpression,
 ): string | null {
-  const names = getMemberAccessNames(expression);
+  const pathInfo = getMemberAccessPathInfo(expression);
+  const names = pathInfo?.names;
 
-  if (!names) {
+  if (!names || pathInfo.hasComputedNonLiteral) {
     return null;
   }
 
@@ -294,6 +333,25 @@ function findDirectBrowserDataName(
   return null;
 }
 
+function isComputedSensitiveAccess(
+  expression: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+): boolean {
+  const pathInfo = getMemberAccessPathInfo(expression);
+  const names = pathInfo?.names;
+
+  if (!pathInfo?.hasComputedNonLiteral || !names) {
+    return false;
+  }
+
+  return (
+    matchesPropertyAccessPath(names, ['document']) ||
+    matchesPropertyAccessPath(names, ['location']) ||
+    matchesPropertyAccessPath(names, ['window', 'location']) ||
+    matchesPropertyAccessPath(names, ['payload']) ||
+    matchesPropertyAccessPath(names, ['tab'])
+  );
+}
+
 function matchesPropertyAccessPath(names: Array<string>, expectedPath: Array<string>): boolean {
   if (names.length !== expectedPath.length) {
     return false;
@@ -308,10 +366,11 @@ function isMemberAccessExpression(
   return ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression);
 }
 
-function getMemberAccessNames(
+function getMemberAccessPathInfo(
   expression: ts.PropertyAccessExpression | ts.ElementAccessExpression,
-): Array<string> | null {
+): { names: Array<string>; hasComputedNonLiteral: boolean } | null {
   const names = new Array<string>();
+  let hasComputedNonLiteral = false;
   let current: ts.Expression = expression;
 
   while (isMemberAccessExpression(current)) {
@@ -324,7 +383,9 @@ function getMemberAccessNames(
     const argumentName = getElementAccessArgumentName(current.argumentExpression);
 
     if (!argumentName) {
-      return null;
+      hasComputedNonLiteral = true;
+      current = current.expression;
+      continue;
     }
 
     names.unshift(argumentName);
@@ -337,7 +398,10 @@ function getMemberAccessNames(
 
   names.unshift(current.text);
 
-  return names;
+  return {
+    names,
+    hasComputedNonLiteral,
+  };
 }
 
 function getElementAccessArgumentName(argument: ts.Expression): string | null {
@@ -348,12 +412,21 @@ function getElementAccessArgumentName(argument: ts.Expression): string | null {
   return null;
 }
 
-function collectVariableInitializers(sourceFile: ts.SourceFile): Map<string, ts.Expression> {
-  const initializers = new Map<string, ts.Expression>();
+function collectVariableInitializers(
+  sourceFile: ts.SourceFile,
+): Map<string, Array<VariableInitializerEntry>> {
+  const initializers = new Map<string, Array<VariableInitializerEntry>>();
 
   function visit(node: ts.Node): void {
     if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
-      initializers.set(node.name.text, node.initializer);
+      const entries = initializers.get(node.name.text) ?? [];
+      entries.push({
+        name: node.name.text,
+        initializer: node.initializer,
+        declarationStart: node.getStart(sourceFile),
+        scopeNode: getDeclarationScopeNode(node),
+      });
+      initializers.set(node.name.text, entries);
     }
 
     ts.forEachChild(node, visit);
@@ -362,4 +435,100 @@ function collectVariableInitializers(sourceFile: ts.SourceFile): Map<string, ts.
   visit(sourceFile);
 
   return initializers;
+}
+
+function resolveVisibleInitializer(
+  initializers: Map<string, Array<VariableInitializerEntry>>,
+  identifier: ts.Identifier,
+): ts.Expression | null {
+  const candidates = initializers.get(identifier.text);
+
+  if (!candidates) {
+    return null;
+  }
+
+  const usageStart = identifier.getStart();
+  const usageScopes = getContainingScopes(identifier);
+  let bestCandidate: VariableInitializerEntry | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (const candidate of candidates) {
+    if (candidate.declarationStart >= usageStart) {
+      continue;
+    }
+
+    const distance = usageScopes.indexOf(candidate.scopeNode);
+
+    if (distance === -1) {
+      continue;
+    }
+
+    if (
+      !bestCandidate ||
+      distance < bestDistance ||
+      (distance === bestDistance && candidate.declarationStart > bestCandidate.declarationStart)
+    ) {
+      bestCandidate = candidate;
+      bestDistance = distance;
+    }
+  }
+
+  return bestCandidate?.initializer ?? null;
+}
+
+function getContainingScopes(node: ts.Node): Array<ts.Node> {
+  const scopes = new Array<ts.Node>();
+  let current: ts.Node | undefined = node;
+
+  while (current) {
+    if (isScopeNode(current)) {
+      scopes.push(current);
+    }
+
+    current = current.parent;
+  }
+
+  return scopes;
+}
+
+function getDeclarationScopeNode(node: ts.VariableDeclaration): ts.Node {
+  const declarationList = node.parent;
+  const isBlockScoped =
+    ts.isVariableDeclarationList(declarationList) &&
+    (declarationList.flags & ts.NodeFlags.BlockScoped) !== 0;
+
+  let current: ts.Node | undefined = node.parent;
+
+  while (current) {
+    if (isBlockScoped) {
+      if (isBlockScopeNode(current)) {
+        return current;
+      }
+    } else if (isVarScopeNode(current)) {
+      return current;
+    }
+
+    current = current.parent;
+  }
+
+  return node.getSourceFile();
+}
+
+function isScopeNode(node: ts.Node): boolean {
+  return isBlockScopeNode(node) || isVarScopeNode(node);
+}
+
+function isBlockScopeNode(node: ts.Node): boolean {
+  return (
+    ts.isSourceFile(node) || ts.isBlock(node) || ts.isCaseClause(node) || ts.isDefaultClause(node)
+  );
+}
+
+function isVarScopeNode(node: ts.Node): boolean {
+  return (
+    ts.isSourceFile(node) ||
+    ts.isFunctionLike(node) ||
+    ts.isModuleBlock(node) ||
+    ts.isConstructorDeclaration(node)
+  );
 }

--- a/scripts/validate-privacy-logging.ts
+++ b/scripts/validate-privacy-logging.ts
@@ -1,0 +1,83 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+import {
+  analyzePrivacyLoggingSource,
+  formatPrivacyLoggingViolation,
+  type PrivacyLoggingViolation,
+} from './privacy-logging-rules';
+
+const DEFAULT_ROOT = 'src';
+const VALID_EXTENSIONS = new Set(['.ts', '.tsx']);
+
+function getScanRoot(): string {
+  const rootIndex = process.argv.indexOf('--root');
+  if (rootIndex === -1) {
+    return DEFAULT_ROOT;
+  }
+
+  const root = process.argv[rootIndex + 1];
+  if (!root) {
+    throw new Error('--root requires a directory path');
+  }
+
+  return root;
+}
+
+function hasSupportedExtension(filePath: string): boolean {
+  return [...VALID_EXTENSIONS].some((extension) => filePath.endsWith(extension));
+}
+
+async function collectSourceFiles(directory: string): Promise<Array<string>> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: Array<string> = [];
+
+  for (const entry of entries) {
+    const fullPath = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') {
+        continue;
+      }
+
+      files.push(...(await collectSourceFiles(fullPath)));
+      continue;
+    }
+
+    if (entry.isFile() && hasSupportedExtension(fullPath)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+async function main() {
+  const root = getScanRoot();
+  const files = await collectSourceFiles(root);
+  const violations: Array<PrivacyLoggingViolation> = [];
+
+  for (const filePath of files) {
+    const sourceText = await readFile(filePath, 'utf8');
+    const relativePath = relative(process.cwd(), filePath);
+    violations.push(...analyzePrivacyLoggingSource(relativePath, sourceText));
+  }
+
+  if (violations.length === 0) {
+    console.log(`Privacy logging validation passed for ${files.length} files.`);
+    return;
+  }
+
+  console.error(`Privacy logging validation failed with ${violations.length} issue(s):`);
+  for (const violation of violations) {
+    console.error(formatPrivacyLoggingViolation(violation));
+  }
+
+  process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error('Privacy logging validation failed unexpectedly:');
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/background/handlers/auto-sync-handlers.test.ts
+++ b/src/background/handlers/auto-sync-handlers.test.ts
@@ -9,7 +9,7 @@ import {
 } from '~/shared/lib/storage';
 import type { AutoSyncGroup } from '~/shared/types/auto-sync-state';
 
-import { removeTabFromAllAutoSyncGroups } from '../lib/auto-sync-groups';
+import { removeTabFromAllAutoSyncGroups, updateAutoSyncGroup } from '../lib/auto-sync-groups';
 import { toggleAutoSync } from '../lib/auto-sync-lifecycle';
 import {
   autoSyncState,
@@ -78,6 +78,7 @@ vi.mock('~/shared/lib/storage', () => ({
 
 vi.mock('../lib/auto-sync-groups', () => ({
   removeTabFromAllAutoSyncGroups: vi.fn(),
+  updateAutoSyncGroup: vi.fn(),
 }));
 
 vi.mock('../lib/auto-sync-lifecycle', () => ({
@@ -176,6 +177,7 @@ describe('registerAutoSyncHandlers', () => {
       incognito: false,
     } as browser.Tabs.Tab);
     vi.mocked(removeTabFromAllAutoSyncGroups).mockResolvedValue();
+    vi.mocked(updateAutoSyncGroup).mockResolvedValue('https://example.com/page');
     vi.mocked(persistSyncState).mockResolvedValue();
     vi.mocked(broadcastSyncStatus).mockResolvedValue();
 
@@ -339,6 +341,24 @@ describe('registerAutoSyncHandlers', () => {
       syncState.isActive = true;
       syncState.linkedTabs = [1, 2];
       syncState.mode = 'ratio';
+      autoSyncState.enabled = true;
+
+      vi.mocked(browser.tabs.get).mockImplementation(async (tabId: number) => {
+        const urlByTabId = new Map([
+          [1, 'https://old.test/one'],
+          [2, 'https://old.test/two'],
+        ]);
+
+        return {
+          id: tabId,
+          index: 0,
+          highlighted: false,
+          active: false,
+          pinned: false,
+          incognito: false,
+          url: urlByTabId.get(tabId),
+        } as browser.Tabs.Tab;
+      });
 
       vi.mocked(sendMessageWithTimeout).mockImplementation(
         async (
@@ -385,6 +405,8 @@ describe('registerAutoSyncHandlers', () => {
       // Verify old tabs are NOT in manualSyncOverriddenTabs
       expect(manualSyncOverriddenTabs.has(1)).toBe(false);
       expect(manualSyncOverriddenTabs.has(2)).toBe(false);
+      expect(updateAutoSyncGroup).toHaveBeenCalledWith(1, 'https://old.test/one');
+      expect(updateAutoSyncGroup).toHaveBeenCalledWith(2, 'https://old.test/two');
 
       // Verify new tabs ARE in manualSyncOverriddenTabs
       expect(manualSyncOverriddenTabs.has(10)).toBe(true);
@@ -440,8 +462,11 @@ describe('registerAutoSyncHandlers', () => {
       expect(syncState.isActive).toBe(false);
       expect(syncState.linkedTabs).toEqual([]);
       expect(syncState.connectionStatuses).toEqual({});
-      expect(persistSyncState).not.toHaveBeenCalled();
-      expect(broadcastSyncStatus).not.toHaveBeenCalled();
+      expect(manualSyncOverriddenTabs.has(1)).toBe(false);
+      expect(manualSyncOverriddenTabs.has(2)).toBe(false);
+      expect(autoSyncState.groups.has(normalizedUrl)).toBe(true);
+      expect(persistSyncState).toHaveBeenCalledTimes(1);
+      expect(broadcastSyncStatus).toHaveBeenCalledTimes(1);
     });
 
     it('returns success when accepted suggestion group no longer exists', async () => {
@@ -627,6 +652,22 @@ describe('registerAutoSyncHandlers', () => {
       expect(response).toEqual({ success: false, error: 'Error: Tab no longer exists' });
       expect(removeTabFromAllAutoSyncGroups).not.toHaveBeenCalled();
       expect(syncState.linkedTabs).toEqual([1, 2]);
+      expect(persistSyncState).not.toHaveBeenCalled();
+      expect(broadcastSyncStatus).not.toHaveBeenCalled();
+    });
+
+    it('ignores duplicate accepted add-tab responses for an already linked tab', async () => {
+      syncState.isActive = true;
+      syncState.linkedTabs = [1, 2, 3];
+      manualSyncOverriddenTabs.add(3);
+
+      const handler = getRequiredHandler('sync-suggestion:add-tab-response');
+      const response = await handler({ data: { tabId: 3, accepted: true }, sender: {} });
+
+      expect(response).toEqual({ success: true });
+      expect(browser.tabs.get).not.toHaveBeenCalled();
+      expect(removeTabFromAllAutoSyncGroups).not.toHaveBeenCalled();
+      expect(syncState.linkedTabs).toEqual([1, 2, 3]);
       expect(persistSyncState).not.toHaveBeenCalled();
       expect(broadcastSyncStatus).not.toHaveBeenCalled();
     });

--- a/src/background/handlers/auto-sync-handlers.ts
+++ b/src/background/handlers/auto-sync-handlers.ts
@@ -10,7 +10,7 @@ import {
 } from '~/shared/lib/storage';
 import type { AutoSyncGroupInfo } from '~/shared/types/messages';
 
-import { removeTabFromAllAutoSyncGroups } from '../lib/auto-sync-groups';
+import { removeTabFromAllAutoSyncGroups, updateAutoSyncGroup } from '../lib/auto-sync-groups';
 import { toggleAutoSync } from '../lib/auto-sync-lifecycle';
 import {
   autoSyncState,
@@ -27,6 +27,64 @@ import { sendMessageWithTimeout } from '../lib/messaging';
 import { syncState, persistSyncState, broadcastSyncStatus } from '../lib/sync-state';
 
 const logger = new ExtensionLogger({ scope: 'background/auto-sync-handlers' });
+
+async function stopManualSyncAndReturnTabsToAutoSync(tabIds: Array<number>): Promise<void> {
+  await Promise.allSettled(
+    tabIds.map((tabId) =>
+      sendMessageWithTimeout(
+        'scroll:stop',
+        { tabIds },
+        { context: 'content-script', tabId },
+        1_000,
+      ),
+    ),
+  );
+
+  if (autoSyncState.enabled) {
+    for (const tabId of tabIds) {
+      manualSyncOverriddenTabs.delete(tabId);
+
+      try {
+        const tab = await browser.tabs.get(tabId);
+        if (tab.url) {
+          await updateAutoSyncGroup(tabId, tab.url);
+        }
+      } catch {
+        // Tab may have been closed.
+      }
+    }
+  } else {
+    for (const tabId of tabIds) {
+      manualSyncOverriddenTabs.delete(tabId);
+    }
+  }
+
+  stopKeepAlive();
+  addTabSuggestedTabs.clear();
+
+  syncState.isActive = false;
+  syncState.linkedTabs = [];
+  syncState.connectionStatuses = {};
+  syncState.mode = undefined;
+
+  await persistSyncState();
+}
+
+async function rollbackFailedSuggestionStart(connectedTabIds: Array<number>): Promise<void> {
+  await Promise.allSettled(
+    connectedTabIds.map((tabId) =>
+      sendMessageWithTimeout('scroll:stop', {}, { context: 'content-script', tabId }, 1_000),
+    ),
+  );
+
+  syncState.isActive = false;
+  syncState.linkedTabs = [];
+  syncState.connectionStatuses = {};
+  syncState.mode = undefined;
+
+  await persistSyncState();
+  await broadcastSyncStatus();
+}
 
 export function registerAutoSyncHandlers(): void {
   onMessage('auto-sync:status-changed', async ({ data }) => {
@@ -154,40 +212,13 @@ export function registerAutoSyncHandlers(): void {
               { previousLinkedTabs: syncState.linkedTabs, newTabIds: tabIds },
             );
 
-            await Promise.allSettled(
-              previousLinkedTabs.map((tabId) =>
-                sendMessageWithTimeout(
-                  'scroll:stop',
-                  { tabIds: previousLinkedTabs },
-                  { context: 'content-script', tabId },
-                  1_000,
-                ),
-              ),
-            );
-
-            for (const oldTabId of previousLinkedTabs) {
-              manualSyncOverriddenTabs.delete(oldTabId);
-            }
-
-            stopKeepAlive();
-            addTabSuggestedTabs.clear();
-
-            syncState.isActive = false;
-            syncState.linkedTabs = [];
-            syncState.connectionStatuses = {};
-            syncState.mode = undefined;
+            await stopManualSyncAndReturnTabsToAutoSync(previousLinkedTabs);
           }
 
           logger.info('[AUTO-SYNC] Starting manual sync from suggestion acceptance', {
             tabCount: tabIds.length,
             tabIds,
           });
-
-          for (const tabId of tabIds) {
-            manualSyncOverriddenTabs.add(tabId);
-          }
-
-          autoSyncState.groups.delete(normalizedUrl);
 
           // ✅ FIX: Set syncState BEFORE starting connections to prevent race condition
           syncState.isActive = true;
@@ -231,14 +262,17 @@ export function registerAutoSyncHandlers(): void {
           const connectedTabIds = successfulConnections.map(([tabId]) => Number(tabId));
 
           if (connectedTabIds.length >= 2) {
+            for (const tabId of connectedTabIds) {
+              manualSyncOverriddenTabs.add(tabId);
+            }
+
+            autoSyncState.groups.delete(normalizedUrl);
             syncState.linkedTabs = connectedTabIds;
             await persistSyncState();
             await broadcastSyncStatus();
             logger.info('[AUTO-SYNC] Manual sync started from suggestion', { connectedTabIds });
           } else {
-            syncState.isActive = false;
-            syncState.linkedTabs = [];
-            syncState.connectionStatuses = {};
+            await rollbackFailedSuggestionStart(connectedTabIds);
             logger.warn('[AUTO-SYNC] Failed to start sync - not enough tabs connected', {
               attemptedTabCount: tabIds.length,
               connectedTabCount: connectedTabIds.length,
@@ -309,6 +343,10 @@ export function registerAutoSyncHandlers(): void {
 
       if (accepted && syncState.isActive) {
         try {
+          if (syncState.linkedTabs.includes(tabId)) {
+            return { success: true };
+          }
+
           const tab = await browser.tabs.get(tabId);
           if (!tab) {
             return { success: false, error: 'Tab no longer exists' };
@@ -318,7 +356,7 @@ export function registerAutoSyncHandlers(): void {
 
           await removeTabFromAllAutoSyncGroups(tabId);
 
-          const newTabIds = [...syncState.linkedTabs, tabId];
+          const newTabIds = [...new Set([...syncState.linkedTabs, tabId])];
 
           const promises = newTabIds.map(async (candidateTabId) => {
             try {

--- a/src/background/handlers/auto-sync-handlers.ts
+++ b/src/background/handlers/auto-sync-handlers.ts
@@ -57,12 +57,6 @@ export function registerAutoSyncHandlers(): void {
   onMessage('auto-sync:get-detailed-status', async ({ sender }) => {
     logger.debug('[AUTO-SYNC] get-detailed-status request', { senderTabId: sender.tabId });
 
-    const allGroups = Array.from(autoSyncState.groups.entries()).map(([url, g]) => ({
-      url,
-      tabCount: g.tabIds.size,
-      tabIds: Array.from(g.tabIds),
-      isActive: g.isActive,
-    }));
     const activeGroups = Array.from(autoSyncState.groups.values()).filter((g) => g.isActive);
     const totalSyncedTabs = activeGroups.reduce((sum, g) => sum + g.tabIds.size, 0);
 
@@ -91,7 +85,7 @@ export function registerAutoSyncHandlers(): void {
       }
     }
 
-    const response = {
+    const status = {
       success: true,
       enabled: autoSyncState.enabled,
       activeGroupCount: activeGroups.length,
@@ -101,30 +95,204 @@ export function registerAutoSyncHandlers(): void {
     };
 
     logger.debug('[AUTO-SYNC] get-detailed-status response', {
-      ...response,
-      allGroups,
       groupCount: autoSyncState.groups.size,
+      activeGroupCount: activeGroups.length,
+      totalSyncedTabs,
+      potentialSyncTabs,
+      hasCurrentTabGroup: currentTabGroup !== undefined,
+      currentTabGroupSize: currentTabGroup?.tabCount,
     });
 
-    return response;
+    return status;
   });
 
-  onMessage('sync-suggestion:response', async ({ data }) => {
-    const payload = data;
-    logger.info('[AUTO-SYNC] Received sync suggestion response', payload);
+  onMessage(
+    'sync-suggestion:response',
+    async ({ data: { accepted, normalizedUrl, permanent, snooze } }) => {
+      logger.info('[AUTO-SYNC] Received sync suggestion response', {
+        accepted,
+        permanent: permanent === true,
+        snooze: snooze === true,
+      });
 
-    pendingSuggestions.delete(payload.normalizedUrl);
+      pendingSuggestions.delete(normalizedUrl);
 
-    // Issue 12 Fix: Broadcast dismiss message to ALL tabs in the group
-    const group = autoSyncState.groups.get(payload.normalizedUrl);
-    if (group) {
-      const uniqueTargetTabs = Array.from(group.tabIds);
+      // Issue 12 Fix: Broadcast dismiss message to ALL tabs in the group
+      const group = autoSyncState.groups.get(normalizedUrl);
+      if (group) {
+        const uniqueTargetTabs = Array.from(group.tabIds);
+
+        Promise.allSettled(
+          uniqueTargetTabs.map((targetTabId) =>
+            sendMessageWithTimeout(
+              'sync-suggestion:dismiss',
+              { normalizedUrl },
+              { context: 'content-script', tabId: targetTabId },
+              1_000,
+            ).catch(() => {
+              // Ignore errors - tab may have been closed or content script not ready
+            }),
+          ),
+        ).then((results) => {
+          const successCount = results.filter((r) => r.status === 'fulfilled').length;
+          logger.debug('[AUTO-SYNC] Dismiss sync suggestion toast broadcast', {
+            totalTabs: uniqueTargetTabs.length,
+            successCount,
+          });
+        });
+      }
+      if (accepted) {
+        const group = autoSyncState.groups.get(normalizedUrl);
+        if (group && group.tabIds.size >= 2) {
+          const tabIds = Array.from(group.tabIds);
+
+          if (syncState.isActive && syncState.linkedTabs.length > 0) {
+            const previousLinkedTabs = [...syncState.linkedTabs];
+
+            logger.info(
+              '[AUTO-SYNC] Stopping existing sync before starting new sync from suggestion',
+              { previousLinkedTabs: syncState.linkedTabs, newTabIds: tabIds },
+            );
+
+            await Promise.allSettled(
+              previousLinkedTabs.map((tabId) =>
+                sendMessageWithTimeout(
+                  'scroll:stop',
+                  { tabIds: previousLinkedTabs },
+                  { context: 'content-script', tabId },
+                  1_000,
+                ),
+              ),
+            );
+
+            for (const oldTabId of previousLinkedTabs) {
+              manualSyncOverriddenTabs.delete(oldTabId);
+            }
+
+            stopKeepAlive();
+            addTabSuggestedTabs.clear();
+
+            syncState.isActive = false;
+            syncState.linkedTabs = [];
+            syncState.connectionStatuses = {};
+            syncState.mode = undefined;
+          }
+
+          logger.info('[AUTO-SYNC] Starting manual sync from suggestion acceptance', {
+            tabCount: tabIds.length,
+            tabIds,
+          });
+
+          for (const tabId of tabIds) {
+            manualSyncOverriddenTabs.add(tabId);
+          }
+
+          autoSyncState.groups.delete(normalizedUrl);
+
+          // ✅ FIX: Set syncState BEFORE starting connections to prevent race condition
+          syncState.isActive = true;
+          syncState.linkedTabs = tabIds;
+          syncState.mode = 'ratio';
+
+          const connectionResults: Record<number, { success: boolean; error?: string }> = {};
+
+          const promises = tabIds.map(async (tabId) => {
+            try {
+              const ack = await sendMessageWithTimeout<{ success: boolean; tabId: number }>(
+                'scroll:start',
+                {
+                  tabIds,
+                  mode: 'ratio',
+                  currentTabId: tabId,
+                  isAutoSync: false,
+                },
+                { context: 'content-script', tabId },
+                2_000,
+              );
+
+              if (ack && ack.success && ack.tabId === tabId) {
+                connectionResults[tabId] = { success: true };
+                syncState.connectionStatuses[tabId] = 'connected';
+              } else {
+                connectionResults[tabId] = { success: false, error: 'Invalid acknowledgment' };
+                syncState.connectionStatuses[tabId] = 'error';
+              }
+            } catch (error) {
+              connectionResults[tabId] = { success: false, error: String(error) };
+              syncState.connectionStatuses[tabId] = 'error';
+            }
+          });
+
+          await Promise.all(promises);
+
+          const successfulConnections = Object.entries(connectionResults).filter(
+            ([, result]) => result.success,
+          );
+          const connectedTabIds = successfulConnections.map(([tabId]) => Number(tabId));
+
+          if (connectedTabIds.length >= 2) {
+            syncState.linkedTabs = connectedTabIds;
+            await persistSyncState();
+            await broadcastSyncStatus();
+            logger.info('[AUTO-SYNC] Manual sync started from suggestion', { connectedTabIds });
+          } else {
+            syncState.isActive = false;
+            syncState.linkedTabs = [];
+            syncState.connectionStatuses = {};
+            logger.warn('[AUTO-SYNC] Failed to start sync - not enough tabs connected', {
+              attemptedTabCount: tabIds.length,
+              connectedTabCount: connectedTabIds.length,
+            });
+          }
+        }
+      } else {
+        dismissedUrlGroups.add(normalizedUrl);
+
+        if (permanent) {
+          const domain = extractDomainFromUrl(normalizedUrl);
+          if (domain) {
+            excludedDomains.add(domain);
+            await saveExcludedDomains(Array.from(excludedDomains));
+            logger.info('[AUTO-SYNC] User permanently excluded domain from suggestions');
+          }
+        } else if (snooze) {
+          const domain = extractDomainFromUrl(normalizedUrl);
+          if (domain) {
+            const expiresAt = Date.now() + SUGGESTION_SNOOZE_DURATION_MS;
+            suggestionSnoozeUntil.set(domain, expiresAt);
+            await saveSuggestionSnooze(domain, expiresAt);
+            logger.info('[AUTO-SYNC] User snoozed sync suggestion for domain', {
+              expiresAt: new Date(expiresAt).toISOString(),
+            });
+          }
+        } else {
+          logger.info('[AUTO-SYNC] Sync suggestion auto-dismissed');
+        }
+      }
+
+      return { success: true };
+    },
+  );
+
+  onMessage(
+    'sync-suggestion:add-tab-response',
+    async ({ data: { accepted, tabId, permanent, snooze, normalizedUrl } }) => {
+      logger.info('[AUTO-SYNC] Received add-tab suggestion response', {
+        accepted,
+        tabId,
+        permanent: permanent === true,
+        snooze: snooze === true,
+      });
+
+      // Issue 10 Fix: Broadcast dismiss message to ALL tabs (synced + new tab)
+      const allTargetTabs = [...syncState.linkedTabs, tabId];
+      const uniqueTargetTabs = [...new Set(allTargetTabs)];
 
       Promise.allSettled(
         uniqueTargetTabs.map((targetTabId) =>
           sendMessageWithTimeout(
-            'sync-suggestion:dismiss',
-            { normalizedUrl: payload.normalizedUrl },
+            'sync-suggestion:dismiss-add-tab',
+            { tabId },
             { context: 'content-script', tabId: targetTabId },
             1_000,
           ).catch(() => {
@@ -133,254 +301,85 @@ export function registerAutoSyncHandlers(): void {
         ),
       ).then((results) => {
         const successCount = results.filter((r) => r.status === 'fulfilled').length;
-        logger.debug('[AUTO-SYNC] Dismiss sync suggestion toast broadcast', {
+        logger.debug('[AUTO-SYNC] Dismiss add-tab toast broadcast', {
           totalTabs: uniqueTargetTabs.length,
           successCount,
         });
       });
-    }
 
-    if (payload.accepted) {
-      const group = autoSyncState.groups.get(payload.normalizedUrl);
-      if (group && group.tabIds.size >= 2) {
-        const tabIds = Array.from(group.tabIds);
-
-        if (syncState.isActive && syncState.linkedTabs.length > 0) {
-          const previousLinkedTabs = [...syncState.linkedTabs];
-
-          logger.info(
-            '[AUTO-SYNC] Stopping existing sync before starting new sync from suggestion',
-            { previousLinkedTabs: syncState.linkedTabs, newTabIds: tabIds },
-          );
-
-          await Promise.allSettled(
-            previousLinkedTabs.map((tabId) =>
-              sendMessageWithTimeout(
-                'scroll:stop',
-                { tabIds: previousLinkedTabs },
-                { context: 'content-script', tabId },
-                1_000,
-              ),
-            ),
-          );
-
-          for (const oldTabId of previousLinkedTabs) {
-            manualSyncOverriddenTabs.delete(oldTabId);
+      if (accepted && syncState.isActive) {
+        try {
+          const tab = await browser.tabs.get(tabId);
+          if (!tab) {
+            return { success: false, error: 'Tab no longer exists' };
           }
 
-          stopKeepAlive();
-          addTabSuggestedTabs.clear();
-
-          syncState.isActive = false;
-          syncState.linkedTabs = [];
-          syncState.connectionStatuses = {};
-          syncState.mode = undefined;
-        }
-
-        logger.info('[AUTO-SYNC] Starting manual sync from suggestion acceptance', {
-          normalizedUrl: payload.normalizedUrl,
-          tabIds,
-        });
-
-        for (const tabId of tabIds) {
           manualSyncOverriddenTabs.add(tabId);
-        }
 
-        autoSyncState.groups.delete(payload.normalizedUrl);
+          await removeTabFromAllAutoSyncGroups(tabId);
 
-        // ✅ FIX: Set syncState BEFORE starting connections to prevent race condition
-        syncState.isActive = true;
-        syncState.linkedTabs = tabIds;
-        syncState.mode = 'ratio';
+          const newTabIds = [...syncState.linkedTabs, tabId];
 
-        const connectionResults: Record<number, { success: boolean; error?: string }> = {};
+          const promises = newTabIds.map(async (candidateTabId) => {
+            try {
+              const ack = await sendMessageWithTimeout<{ success: boolean; tabId: number }>(
+                'scroll:start',
+                {
+                  tabIds: newTabIds,
+                  mode: syncState.mode || 'ratio',
+                  currentTabId: candidateTabId,
+                  isAutoSync: false,
+                },
+                { context: 'content-script', tabId: candidateTabId },
+                2_000,
+              );
 
-        const promises = tabIds.map(async (tabId) => {
-          try {
-            const response = await sendMessageWithTimeout<{ success: boolean; tabId: number }>(
-              'scroll:start',
-              {
-                tabIds,
-                mode: 'ratio',
-                currentTabId: tabId,
-                isAutoSync: false,
-              },
-              { context: 'content-script', tabId },
-              2_000,
-            );
-
-            if (response && response.success && response.tabId === tabId) {
-              connectionResults[tabId] = { success: true };
-              syncState.connectionStatuses[tabId] = 'connected';
-            } else {
-              connectionResults[tabId] = { success: false, error: 'Invalid acknowledgment' };
-              syncState.connectionStatuses[tabId] = 'error';
+              if (ack && ack.success && ack.tabId === candidateTabId) {
+                syncState.connectionStatuses[candidateTabId] = 'connected';
+              } else {
+                syncState.connectionStatuses[candidateTabId] = 'error';
+              }
+            } catch {
+              syncState.connectionStatuses[candidateTabId] = 'error';
             }
-          } catch (error) {
-            connectionResults[tabId] = { success: false, error: String(error) };
-            syncState.connectionStatuses[tabId] = 'error';
-          }
-        });
+          });
 
-        await Promise.all(promises);
+          await Promise.all(promises);
 
-        const successfulConnections = Object.entries(connectionResults).filter(
-          ([, result]) => result.success,
-        );
-        const connectedTabIds = successfulConnections.map(([tabId]) => Number(tabId));
-
-        if (connectedTabIds.length >= 2) {
-          syncState.linkedTabs = connectedTabIds;
+          syncState.linkedTabs = newTabIds;
           await persistSyncState();
           await broadcastSyncStatus();
-          logger.info('[AUTO-SYNC] Manual sync started from suggestion', { connectedTabIds });
-        } else {
-          syncState.isActive = false;
-          syncState.linkedTabs = [];
-          syncState.connectionStatuses = {};
-          logger.warn('[AUTO-SYNC] Failed to start sync - not enough tabs connected', {
-            connectionResults,
-          });
-        }
-      }
-    } else {
-      dismissedUrlGroups.add(payload.normalizedUrl);
 
-      if (payload.permanent) {
-        const domain = extractDomainFromUrl(payload.normalizedUrl);
+          logger.info('[AUTO-SYNC] Added tab to manual sync', { tabId, newTabIds });
+        } catch (error) {
+          logger.error('[AUTO-SYNC] Failed to add tab to sync', { tabId, error });
+          return { success: false, error: String(error) };
+        }
+      } else if (!accepted && permanent && normalizedUrl) {
+        const domain = extractDomainFromUrl(normalizedUrl);
         if (domain) {
           excludedDomains.add(domain);
           await saveExcludedDomains(Array.from(excludedDomains));
-          logger.info('[AUTO-SYNC] User permanently excluded domain from suggestions', {
-            normalizedUrl: payload.normalizedUrl,
-            domain,
+          logger.info('[AUTO-SYNC] User permanently excluded domain from add-tab suggestions', {
+            tabId,
           });
         }
-      } else if (payload.snooze) {
-        const domain = extractDomainFromUrl(payload.normalizedUrl);
+      } else if (!accepted && snooze && normalizedUrl) {
+        const domain = extractDomainFromUrl(normalizedUrl);
         if (domain) {
           const expiresAt = Date.now() + SUGGESTION_SNOOZE_DURATION_MS;
           suggestionSnoozeUntil.set(domain, expiresAt);
           await saveSuggestionSnooze(domain, expiresAt);
-          logger.info('[AUTO-SYNC] User snoozed sync suggestion for domain', {
-            normalizedUrl: payload.normalizedUrl,
-            domain,
+          logger.info('[AUTO-SYNC] User snoozed add-tab suggestion for domain', {
+            tabId,
             expiresAt: new Date(expiresAt).toISOString(),
           });
         }
-      } else {
-        logger.info('[AUTO-SYNC] Sync suggestion auto-dismissed', {
-          normalizedUrl: payload.normalizedUrl,
-        });
       }
-    }
 
-    return { success: true };
-  });
-
-  onMessage('sync-suggestion:add-tab-response', async ({ data }) => {
-    const payload = data;
-    logger.info('[AUTO-SYNC] Received add-tab suggestion response', payload);
-
-    // Issue 10 Fix: Broadcast dismiss message to ALL tabs (synced + new tab)
-    const allTargetTabs = [...syncState.linkedTabs, payload.tabId];
-    const uniqueTargetTabs = [...new Set(allTargetTabs)];
-
-    Promise.allSettled(
-      uniqueTargetTabs.map((targetTabId) =>
-        sendMessageWithTimeout(
-          'sync-suggestion:dismiss-add-tab',
-          { tabId: payload.tabId },
-          { context: 'content-script', tabId: targetTabId },
-          1_000,
-        ).catch(() => {
-          // Ignore errors - tab may have been closed or content script not ready
-        }),
-      ),
-    ).then((results) => {
-      const successCount = results.filter((r) => r.status === 'fulfilled').length;
-      logger.debug('[AUTO-SYNC] Dismiss add-tab toast broadcast', {
-        totalTabs: uniqueTargetTabs.length,
-        successCount,
-      });
-    });
-
-    if (payload.accepted && syncState.isActive) {
-      const tabId = payload.tabId;
-
-      try {
-        const tab = await browser.tabs.get(tabId);
-        if (!tab) {
-          return { success: false, error: 'Tab no longer exists' };
-        }
-
-        manualSyncOverriddenTabs.add(tabId);
-
-        await removeTabFromAllAutoSyncGroups(tabId);
-
-        const newTabIds = [...syncState.linkedTabs, tabId];
-
-        const promises = newTabIds.map(async (tId) => {
-          try {
-            const response = await sendMessageWithTimeout<{ success: boolean; tabId: number }>(
-              'scroll:start',
-              {
-                tabIds: newTabIds,
-                mode: syncState.mode || 'ratio',
-                currentTabId: tId,
-                isAutoSync: false,
-              },
-              { context: 'content-script', tabId: tId },
-              2_000,
-            );
-
-            if (response && response.success && response.tabId === tId) {
-              syncState.connectionStatuses[tId] = 'connected';
-            } else {
-              syncState.connectionStatuses[tId] = 'error';
-            }
-          } catch {
-            syncState.connectionStatuses[tId] = 'error';
-          }
-        });
-
-        await Promise.all(promises);
-
-        syncState.linkedTabs = newTabIds;
-        await persistSyncState();
-        await broadcastSyncStatus();
-
-        logger.info('[AUTO-SYNC] Added tab to manual sync', { tabId, newTabIds });
-      } catch (error) {
-        logger.error('[AUTO-SYNC] Failed to add tab to sync', { tabId, error });
-        return { success: false, error: String(error) };
-      }
-    } else if (!payload.accepted && payload.permanent && payload.normalizedUrl) {
-      const domain = extractDomainFromUrl(payload.normalizedUrl);
-      if (domain) {
-        excludedDomains.add(domain);
-        await saveExcludedDomains(Array.from(excludedDomains));
-        logger.info('[AUTO-SYNC] User permanently excluded domain from add-tab suggestions', {
-          tabId: payload.tabId,
-          domain,
-        });
-      }
-    } else if (!payload.accepted && payload.snooze && payload.normalizedUrl) {
-      const domain = extractDomainFromUrl(payload.normalizedUrl);
-      if (domain) {
-        const expiresAt = Date.now() + SUGGESTION_SNOOZE_DURATION_MS;
-        suggestionSnoozeUntil.set(domain, expiresAt);
-        await saveSuggestionSnooze(domain, expiresAt);
-        logger.info('[AUTO-SYNC] User snoozed add-tab suggestion for domain', {
-          tabId: payload.tabId,
-          domain,
-          expiresAt: new Date(expiresAt).toISOString(),
-        });
-      }
-    }
-
-    return { success: true };
-  });
+      return { success: true };
+    },
+  );
 
   onMessage('auto-sync:excluded-domains-changed', async ({ data }) => {
     const { domains } = data;
@@ -389,7 +388,9 @@ export function registerAutoSyncHandlers(): void {
       excludedDomains.add(domain);
     }
     await saveExcludedDomains(domains);
-    logger.info('[AUTO-SYNC] Excluded domains updated from popup', { domains });
+    logger.info('[AUTO-SYNC] Excluded domains updated from popup', {
+      domainCount: domains.length,
+    });
   });
 
   onMessage('auto-sync:get-excluded-domains', async () => {

--- a/src/background/handlers/connection-handlers.ts
+++ b/src/background/handlers/connection-handlers.ts
@@ -56,14 +56,14 @@ export function registerConnectionHandlers(): void {
 
   onMessage('scroll:ping', async ({ data }) => {
     const payload = data;
-    logger.debug('Received connection health ping', { payload });
+    logger.debug('Received connection health ping', { tabId: payload.tabId });
 
     return { success: true, timestamp: Date.now(), tabId: payload.tabId };
   });
 
   onMessage('scroll:reconnect', async ({ data }) => {
     const payload = data;
-    logger.info('Received reconnection request from content script', { payload });
+    logger.info('Received reconnection request from content script', { tabId: payload.tabId });
 
     const isInManualSync = syncState.isActive && syncState.linkedTabs.includes(payload.tabId);
     const isInAutoSync = isTabInActiveAutoSyncGroup(payload.tabId);
@@ -79,8 +79,8 @@ export function registerConnectionHandlers(): void {
     }
 
     try {
-      const tab = await browser.tabs.get(payload.tabId);
-      logger.debug('Tab verified for reconnection', { tabId: tab.id, url: tab.url });
+      await browser.tabs.get(payload.tabId);
+      logger.debug('Tab verified for reconnection', { tabId: payload.tabId });
     } catch (error) {
       logger.error('Tab no longer exists, removing from sync', { tabId: payload.tabId, error });
       if (isInManualSync) {
@@ -123,7 +123,7 @@ export function registerConnectionHandlers(): void {
         });
         return { success: true };
       } else {
-        logger.error('Invalid reconnection acknowledgment', { response });
+        logger.error('Invalid reconnection acknowledgment', { tabId: payload.tabId });
         if (isInManualSync) {
           syncState.connectionStatuses[payload.tabId] = 'error';
           await persistSyncState();

--- a/src/background/handlers/scroll-sync-handlers.ts
+++ b/src/background/handlers/scroll-sync-handlers.ts
@@ -53,7 +53,9 @@ export function registerScrollSyncHandlers(): void {
     const connectionResults: Record<number, { success: boolean; error?: string }> = {};
 
     // Attempt to connect to each tab with timeout and acknowledgment validation
-    logger.info(`Connecting to ${startRequest.tabIds.length} tabs`, { tabIds: startRequest.tabIds });
+    logger.info(`Connecting to ${startRequest.tabIds.length} tabs`, {
+      tabIds: startRequest.tabIds,
+    });
 
     const promises = startRequest.tabIds.map(async (tabId) => {
       try {

--- a/src/background/handlers/scroll-sync-handlers.ts
+++ b/src/background/handlers/scroll-sync-handlers.ts
@@ -22,13 +22,16 @@ const logger = new ExtensionLogger({ scope: 'background/scroll-sync-handlers' })
 
 export function registerScrollSyncHandlers(): void {
   logger.info('Registering scroll:start handler');
-  onMessage('scroll:start', async ({ data }) => {
-    logger.info('Received scroll:start message', { data });
-    const payload = data;
+  onMessage('scroll:start', async ({ data: startRequest }) => {
+    logger.info('Received scroll:start message', {
+      requestedTabCount: startRequest.tabIds.length,
+      mode: startRequest.mode,
+      isAutoSync: startRequest.isAutoSync ?? false,
+    });
 
     // If this is a manual sync (not auto-sync), handle conflict with auto-sync
-    if (!payload.isAutoSync) {
-      for (const tabId of payload.tabIds) {
+    if (!startRequest.isAutoSync) {
+      for (const tabId of startRequest.tabIds) {
         manualSyncOverriddenTabs.add(tabId);
         await removeTabFromAllAutoSyncGroups(tabId);
       }
@@ -42,7 +45,7 @@ export function registerScrollSyncHandlers(): void {
       }
 
       logger.debug('Manual sync started, tabs excluded from auto-sync', {
-        tabIds: payload.tabIds,
+        tabIds: startRequest.tabIds,
       });
     }
 
@@ -50,20 +53,20 @@ export function registerScrollSyncHandlers(): void {
     const connectionResults: Record<number, { success: boolean; error?: string }> = {};
 
     // Attempt to connect to each tab with timeout and acknowledgment validation
-    logger.info(`Connecting to ${payload.tabIds.length} tabs`, { tabIds: payload.tabIds });
+    logger.info(`Connecting to ${startRequest.tabIds.length} tabs`, { tabIds: startRequest.tabIds });
 
-    const promises = payload.tabIds.map(async (tabId) => {
+    const promises = startRequest.tabIds.map(async (tabId) => {
       try {
         // Verify tab exists first
-        const tab = await browser.tabs.get(tabId);
-        logger.debug(`Verified tab ${tabId} exists:`, { title: tab.title, url: tab.url });
+        await browser.tabs.get(tabId);
+        logger.debug(`Verified tab ${tabId} exists`);
 
         logger.debug(`Sending scroll:start to tab ${tabId}`);
 
         // Send message with timeout and capture acknowledgment
         const response = await sendMessageWithTimeout<{ success: boolean; tabId: number }>(
           'scroll:start',
-          { ...payload, currentTabId: tabId },
+          { ...startRequest, currentTabId: tabId },
           { context: 'content-script', tabId },
           1_000, // 1 second timeout
         );
@@ -74,7 +77,7 @@ export function registerScrollSyncHandlers(): void {
           connectionResults[tabId] = { success: true };
           syncState.connectionStatuses[tabId] = 'connected';
         } else {
-          logger.error(`Tab ${tabId} returned invalid acknowledgment`, { response });
+          logger.error(`Tab ${tabId} returned invalid acknowledgment`);
           connectionResults[tabId] = { success: false, error: 'Invalid acknowledgment' };
           syncState.connectionStatuses[tabId] = 'error';
         }
@@ -95,9 +98,9 @@ export function registerScrollSyncHandlers(): void {
     const connectedTabIds = successfulConnections.map(([tabId]) => Number(tabId));
 
     logger.info('Connection results', {
-      total: payload.tabIds.length,
+      total: startRequest.tabIds.length,
       successful: successfulConnections.length,
-      failed: payload.tabIds.length - successfulConnections.length,
+      failed: startRequest.tabIds.length - successfulConnections.length,
       results: connectionResults,
     });
 
@@ -129,7 +132,7 @@ export function registerScrollSyncHandlers(): void {
     // Update sync state with only successfully connected tabs
     syncState.isActive = true;
     syncState.linkedTabs = connectedTabIds;
-    syncState.mode = payload.mode;
+    syncState.mode = startRequest.mode;
 
     // Start keep-alive mechanism to prevent service worker termination
     startKeepAlive();
@@ -150,9 +153,12 @@ export function registerScrollSyncHandlers(): void {
   });
 
   onMessage('scroll:stop', async ({ data }) => {
-    logger.info('Stopping scroll sync for tabs', { data });
     const payload = data;
     const tabIds = payload.tabIds ?? [];
+    logger.info('Stopping scroll sync for tabs', {
+      tabCount: tabIds.length,
+      isAutoSync: payload.isAutoSync ?? false,
+    });
 
     // Broadcast stop message to all selected tabs
     const promises = tabIds.map((tabId) =>
@@ -165,13 +171,13 @@ export function registerScrollSyncHandlers(): void {
 
     // Also stop any auto-sync groups that contain these tabs
     // This ensures auto-sync state is cleared when user stops from popup
-    for (const [normalizedUrl, group] of autoSyncState.groups.entries()) {
+    for (const [, group] of autoSyncState.groups.entries()) {
       if (group.isActive) {
         const hasStoppedTab = tabIds.some((tabId) => group.tabIds.has(tabId));
         if (hasStoppedTab) {
           logger.info('[AUTO-SYNC] Clearing auto-sync group due to manual stop', {
-            normalizedUrl,
             stoppedTabIds: tabIds,
+            groupTabCount: group.tabIds.size,
           });
           group.isActive = false;
         }
@@ -214,8 +220,11 @@ export function registerScrollSyncHandlers(): void {
 
   onMessage('scroll:sync', async ({ data, sender }) => {
     const payload = data;
-
-    logger.debug('Relaying scroll sync message', { payload, sender });
+    logger.debug('Relaying scroll sync message', {
+      sourceTabId: payload.sourceTabId,
+      mode: payload.mode,
+      hasSenderTab: sender.tabId !== undefined,
+    });
 
     // Manual sync tabs (existing logic)
     let targetTabIds = syncState.linkedTabs.filter((tabId) => tabId !== payload.sourceTabId);
@@ -247,8 +256,11 @@ export function registerScrollSyncHandlers(): void {
   });
 
   onMessage('scroll:manual', async ({ data }) => {
-    logger.debug('Manual scroll mode toggled', { data });
     const payload = data;
+    logger.debug('Manual scroll mode toggled', {
+      tabId: payload.tabId,
+      enabled: payload.enabled,
+    });
 
     // Send manual mode change to the specific tab only
     try {
@@ -265,7 +277,7 @@ export function registerScrollSyncHandlers(): void {
 
   onMessage('url:sync', async ({ data }) => {
     const payload = data;
-    logger.info('Relaying URL sync message', { payload });
+    logger.info('Relaying URL sync message', { sourceTabId: payload.sourceTabId });
 
     // Broadcast to all synced tabs except the source
     const targetTabIds = syncState.linkedTabs.filter((tabId) => tabId !== payload.sourceTabId);

--- a/src/background/handlers/tab-event-handlers.ts
+++ b/src/background/handlers/tab-event-handlers.ts
@@ -265,9 +265,7 @@ export function registerTabEventHandlers(): void {
     }
 
     if (tab.url && tab.url !== 'about:blank' && tab.url !== 'chrome://newtab/') {
-      logger.debug(`New tab ${tab.id} created with URL, adding to auto-sync group (pending)`, {
-        url: tab.url,
-      });
+      logger.debug(`New tab ${tab.id} created with URL, adding to auto-sync group (pending)`);
       const groupKey = await updateAutoSyncGroup(tab.id, tab.url, true, true);
 
       // ✅ FIX: Show suggestion after content script is ready (delayed)
@@ -288,13 +286,13 @@ export function registerTabEventHandlers(): void {
               if (pendingSuggestions.has(normalizedUrl) && tab.id !== undefined) {
                 logger.info('[AUTO-SYNC] Sending suggestion to newly joined tab', {
                   tabId: tab.id,
-                  normalizedUrl,
+                  groupTabCount: currentGroup.tabIds.size,
                 });
                 await sendSuggestionToSingleTab(tab.id, normalizedUrl, currentGroup);
               } else {
                 logger.info('[AUTO-SYNC] Showing delayed suggestion after tab creation', {
                   tabId: tab.id,
-                  normalizedUrl,
+                  groupTabCount: currentGroup.tabIds.size,
                 });
                 await showSyncSuggestion(normalizedUrl);
               }
@@ -336,8 +334,8 @@ export function registerTabEventHandlers(): void {
             addTabSuggestedTabs.add(tabId);
             logger.info('[AUTO-SYNC] Detected new tab with same URL as synced tab (immediate)', {
               tabId,
-              normalizedUrl,
               trigger: changeInfo.url ? 'url_change' : 'loading_with_url',
+              sourceMatchCount: matchingSyncedTabSignatures.length,
             });
             const isTranslatedPageMatch =
               newTabSignature?.matchKind === 'translated-page' ||
@@ -358,7 +356,6 @@ export function registerTabEventHandlers(): void {
               addTabSuggestedTabs.add(tabId);
               logger.info('[AUTO-SYNC] Detected translated metadata match for active sync tab', {
                 tabId,
-                normalizedUrl: metadataMatch.normalizedUrl,
                 trigger: changeInfo.url ? 'url_change' : 'loading_with_url',
               });
 
@@ -421,7 +418,7 @@ export function registerTabEventHandlers(): void {
 
     if (changeInfo.url) {
       const changedUrl = changeInfo.url;
-      logger.info(`Synced tab ${tabId} URL changed, broadcasting`, { url: changedUrl });
+      logger.info(`Synced tab ${tabId} URL changed, broadcasting`, { tabId });
 
       const urlSyncEnabled = await loadUrlSyncEnabled();
       if (urlSyncEnabled) {
@@ -444,7 +441,7 @@ export function registerTabEventHandlers(): void {
       return;
     }
 
-    logger.info(`Synced tab ${tabId} was refreshed/updated, reconnecting`, { url: tab.url });
+    logger.info(`Synced tab ${tabId} was refreshed/updated, reconnecting`, { tabId });
 
     try {
       await sendMessage(

--- a/src/background/lib/auto-sync-groups.ts
+++ b/src/background/lib/auto-sync-groups.ts
@@ -521,7 +521,10 @@ export function removeTabFromAutoSyncGroup(normalizedUrl: string, tabId: number)
 
   group.tabIds.delete(tabId);
   group.tabUrls?.delete(tabId);
-  logger.debug(`Removed tab ${tabId} from auto-sync group`, { tabId, remainingTabCount: group.tabIds.size });
+  logger.debug(`Removed tab ${tabId} from auto-sync group`, {
+    tabId,
+    remainingTabCount: group.tabIds.size,
+  });
 
   if (group.tabIds.size === 0) {
     autoSyncState.groups.delete(normalizedUrl);

--- a/src/background/lib/auto-sync-groups.ts
+++ b/src/background/lib/auto-sync-groups.ts
@@ -497,8 +497,9 @@ async function refreshTranslatedPageCandidateGroupsFromSnapshots(
     didMergeCandidate = true;
     logger.info('[AUTO-SYNC] Refreshed translated page candidate group', {
       tabId: sourceSnapshot.tabId,
-      sourceGroupKey: sourceSnapshot.groupKey,
-      targetGroupKey: candidate.normalizedUrl,
+      sourceGroupTabCount: 1,
+      targetGroupTabCount:
+        autoSyncState.groups.get(candidate.normalizedUrl)?.tabIds.size ?? undefined,
       matchKind: candidate.matchKind,
       matchConfidence: candidate.matchConfidence,
     });
@@ -520,11 +521,11 @@ export function removeTabFromAutoSyncGroup(normalizedUrl: string, tabId: number)
 
   group.tabIds.delete(tabId);
   group.tabUrls?.delete(tabId);
-  logger.debug(`Removed tab ${tabId} from auto-sync group`, { normalizedUrl });
+  logger.debug(`Removed tab ${tabId} from auto-sync group`, { tabId, remainingTabCount: group.tabIds.size });
 
   if (group.tabIds.size === 0) {
     autoSyncState.groups.delete(normalizedUrl);
-    logger.debug(`Removed empty auto-sync group`, { normalizedUrl });
+    logger.debug('Removed empty auto-sync group');
   } else {
     recomputeAutoSyncGroupMetadata(group);
   }
@@ -553,7 +554,7 @@ export async function stopAutoSyncForGroup(normalizedUrl: string): Promise<void>
   if (!group) return;
 
   const tabIds = Array.from(group.tabIds);
-  logger.info(`Stopping auto-sync for group`, { normalizedUrl, tabIds });
+  logger.info('Stopping auto-sync for group', { tabCount: tabIds.length, tabIds });
 
   const promises = tabIds.map(async (tabId) => {
     try {
@@ -667,7 +668,7 @@ export async function updateAutoSyncGroup(
   if (candidateApplyResolution.status === 'source-stale') {
     logger.info('[AUTO-SYNC] Tab URL changed before translated candidate apply', {
       tabId,
-      normalizedUrl: preparation.lookup.context.normalizedUrl,
+      skipStartSync: preparation.lookup.context.skipStartSync,
     });
     return null;
   }
@@ -675,8 +676,7 @@ export async function updateAutoSyncGroup(
   if (candidate && !candidateApplyResolution.state) {
     logger.info('[AUTO-SYNC] Translated page candidate became stale before apply', {
       tabId,
-      normalizedUrl: preparation.lookup.context.normalizedUrl,
-      candidateUrl: candidate.normalizedUrl,
+      hadCandidate: true,
     });
   }
 
@@ -697,7 +697,6 @@ async function prepareUpdateAutoSyncGroup(
 ): Promise<UpdateAutoSyncGroupPreparation> {
   logger.info('[AUTO-SYNC] updateAutoSyncGroupInternal called', {
     tabId,
-    url,
     skipStartSync,
     skipBroadcast,
   });
@@ -725,19 +724,19 @@ async function prepareUpdateAutoSyncGroup(
   };
 
   if (isForbiddenUrl(url)) {
-    logger.debug(`[AUTO-SYNC] URL is forbidden, skipping auto-sync`, { url, tabId });
+    logger.debug('[AUTO-SYNC] URL is forbidden, skipping auto-sync', { tabId });
     await removeTabFromAllAutoSyncGroups(tabId);
     return { status: 'complete', result: null };
   }
 
   if (isLocalDevelopmentServer(url)) {
-    logger.debug(`[AUTO-SYNC] URL is local dev server, skipping auto-sync`, { url, tabId });
+    logger.debug('[AUTO-SYNC] URL is local dev server, skipping auto-sync', { tabId });
     await removeTabFromAllAutoSyncGroups(tabId);
     return { status: 'complete', result: null };
   }
 
   if (isUrlExcluded(url, autoSyncState.excludedUrls)) {
-    logger.debug(`[AUTO-SYNC] URL excluded from auto-sync`, { url, tabId });
+    logger.debug('[AUTO-SYNC] URL excluded from auto-sync', { tabId });
     await removeTabFromAllAutoSyncGroups(tabId);
     return { status: 'complete', result: null };
   }
@@ -859,8 +858,7 @@ async function applyUpdateAutoSyncGroup(
   }
 
   if (isForbiddenUrl(context.url)) {
-    logger.debug(`[AUTO-SYNC] URL is forbidden before apply, skipping auto-sync`, {
-      url: context.url,
+    logger.debug('[AUTO-SYNC] URL is forbidden before apply, skipping auto-sync', {
       tabId: context.tabId,
     });
     await removeTabFromAllAutoSyncGroups(context.tabId);
@@ -868,8 +866,7 @@ async function applyUpdateAutoSyncGroup(
   }
 
   if (isLocalDevelopmentServer(context.url)) {
-    logger.debug(`[AUTO-SYNC] URL is local dev server before apply, skipping auto-sync`, {
-      url: context.url,
+    logger.debug('[AUTO-SYNC] URL is local dev server before apply, skipping auto-sync', {
       tabId: context.tabId,
     });
     await removeTabFromAllAutoSyncGroups(context.tabId);
@@ -877,8 +874,7 @@ async function applyUpdateAutoSyncGroup(
   }
 
   if (isUrlExcluded(context.url, autoSyncState.excludedUrls)) {
-    logger.debug(`[AUTO-SYNC] URL excluded from auto-sync before apply`, {
-      url: context.url,
+    logger.debug('[AUTO-SYNC] URL excluded from auto-sync before apply', {
       tabId: context.tabId,
     });
     await removeTabFromAllAutoSyncGroups(context.tabId);
@@ -918,12 +914,14 @@ async function applyUpdateAutoSyncGroup(
       tabUrls: new Map(),
     };
     autoSyncState.groups.set(groupKey, group);
-    logger.info('[AUTO-SYNC] Created new group', { normalizedUrl: groupKey });
+    logger.info('[AUTO-SYNC] Created new group', {
+      tabId: context.tabId,
+      groupCount: autoSyncState.groups.size,
+    });
   }
 
   if (group.tabIds.size >= MAX_AUTO_SYNC_GROUP_SIZE && !group.tabIds.has(context.tabId)) {
     logger.warn('[AUTO-SYNC] Group size limit reached, tab not added', {
-      normalizedUrl: groupKey,
       currentSize: group.tabIds.size,
       maxSize: MAX_AUTO_SYNC_GROUP_SIZE,
       tabId: context.tabId,
@@ -943,7 +941,6 @@ async function applyUpdateAutoSyncGroup(
 
   logger.info('[AUTO-SYNC] Tab added to group', {
     tabId: context.tabId,
-    normalizedUrl: groupKey,
     groupSize: group.tabIds.size,
     groupTabIds: Array.from(group.tabIds),
     isNewGroup,
@@ -967,12 +964,12 @@ async function applyUpdateAutoSyncGroup(
     if (pendingSuggestions.has(groupKey)) {
       logger.info('[AUTO-SYNC] Sending suggestion to newly joined tab (from updateAutoSyncGroup)', {
         tabId: context.tabId,
-        normalizedUrl: groupKey,
+        groupTabCount: group.tabIds.size,
       });
       await sendSuggestionToSingleTab(context.tabId, groupKey, group);
     } else {
       logger.info('[AUTO-SYNC] Showing suggestion for group', {
-        normalizedUrl: groupKey,
+        groupTabCount: group.tabIds.size,
         tabIds: Array.from(group.tabIds),
       });
       await showSyncSuggestion(groupKey);

--- a/src/background/lib/auto-sync-lifecycle.ts
+++ b/src/background/lib/auto-sync-lifecycle.ts
@@ -66,9 +66,9 @@ export async function initializeAutoSync(overrideEnabled?: boolean): Promise<voi
 
     logger.info('[AUTO-SYNC] State loaded', {
       enabled: autoSyncState.enabled,
-      excludedUrls: autoSyncState.excludedUrls,
-      excludedDomains: storedExcludedDomains,
-      activeSnoozeDomains: Object.keys(activeSnoozes),
+      excludedUrlCount: autoSyncState.excludedUrls.length,
+      excludedDomainCount: storedExcludedDomains.length,
+      activeSnoozeCount: Object.keys(activeSnoozes).length,
     });
 
     if (!autoSyncState.enabled) {
@@ -81,20 +81,18 @@ export async function initializeAutoSync(overrideEnabled?: boolean): Promise<voi
 
     for (const tab of tabs) {
       if (tab.id && tab.url) {
-        logger.info('[AUTO-SYNC] Processing tab', { tabId: tab.id, url: tab.url });
+        logger.info('[AUTO-SYNC] Processing tab', { tabId: tab.id });
         await updateAutoSyncGroup(tab.id, tab.url, true, true);
       }
     }
 
     logger.info('[AUTO-SYNC] Tab scanning complete, checking for eligible groups', {
       groupCount: autoSyncState.groups.size,
-      groups: Array.from(autoSyncState.groups.entries()).map(([url, g]) => ({
-        url,
-        tabCount: g.tabIds.size,
-        tabIds: Array.from(g.tabIds),
-        isActive: g.isActive,
-        matchKind: g.matchKind,
-        matchConfidence: g.matchConfidence,
+      groups: Array.from(autoSyncState.groups.values()).map((group) => ({
+        tabCount: group.tabIds.size,
+        isActive: group.isActive,
+        matchKind: group.matchKind,
+        matchConfidence: group.matchConfidence,
       })),
     });
 
@@ -105,7 +103,7 @@ export async function initializeAutoSync(overrideEnabled?: boolean): Promise<voi
       if (group.tabIds.size >= 2) {
         const tabIds = Array.from(group.tabIds);
         logger.info('[AUTO-SYNC] Injecting content scripts for group', {
-          normalizedUrl,
+          groupTabCount: tabIds.length,
           tabIds,
         });
 
@@ -130,16 +128,14 @@ export async function initializeAutoSync(overrideEnabled?: boolean): Promise<voi
             removeTabFromAutoSyncGroup(normalizedUrl, result.value.tabId);
             logger.info('[AUTO-SYNC] Removed tab from group due to injection failure', {
               tabId: result.value.tabId,
-              normalizedUrl,
+              remainingGroupCount: autoSyncState.groups.size,
             });
           }
         }
 
         if (group.tabIds.size < 2) {
           autoSyncState.groups.delete(normalizedUrl);
-          logger.info('[AUTO-SYNC] Deleted group due to insufficient tabs after injection', {
-            normalizedUrl,
-          });
+          logger.info('[AUTO-SYNC] Deleted group due to insufficient tabs after injection');
         }
       }
     }
@@ -150,8 +146,8 @@ export async function initializeAutoSync(overrideEnabled?: boolean): Promise<voi
     for (const [normalizedUrl, group] of autoSyncState.groups.entries()) {
       if (group.tabIds.size >= 2 && !group.isActive) {
         logger.info('[AUTO-SYNC] Scheduling suggestion for group during init', {
-          normalizedUrl,
           tabIds: Array.from(group.tabIds),
+          groupTabCount: group.tabIds.size,
         });
         if (!pendingSuggestions.has(normalizedUrl) && !dismissedUrlGroups.has(normalizedUrl)) {
           await showSyncSuggestion(normalizedUrl);
@@ -164,13 +160,11 @@ export async function initializeAutoSync(overrideEnabled?: boolean): Promise<voi
 
     logger.info('[AUTO-SYNC] Initialization complete', {
       groupCount: autoSyncState.groups.size,
-      groups: Array.from(autoSyncState.groups.entries()).map(([url, g]) => ({
-        url,
-        tabCount: g.tabIds.size,
-        tabIds: Array.from(g.tabIds),
-        isActive: g.isActive,
-        matchKind: g.matchKind,
-        matchConfidence: g.matchConfidence,
+      groups: Array.from(autoSyncState.groups.values()).map((group) => ({
+        tabCount: group.tabIds.size,
+        isActive: group.isActive,
+        matchKind: group.matchKind,
+        matchConfidence: group.matchConfidence,
       })),
     });
   } catch (error) {

--- a/src/background/lib/auto-sync-suggestions.ts
+++ b/src/background/lib/auto-sync-suggestions.ts
@@ -53,52 +53,42 @@ export function isDomainSnoozed(normalizedUrl: string): boolean {
  */
 export async function showSyncSuggestion(normalizedUrl: string): Promise<void> {
   const group = autoSyncState.groups.get(normalizedUrl);
+  const hasAnyPendingSuggestions = pendingSuggestions.size > 0;
+  const hasAnyDismissedGroups = dismissedUrlGroups.size > 0;
 
   // Comprehensive debug logging for troubleshooting toast display issues
   logger.info('[AUTO-SYNC] showSyncSuggestion called', {
-    normalizedUrl,
-    groupExists: !!group,
-    groupSize: group?.tabIds.size,
-    groupTabIds: group ? Array.from(group.tabIds) : [],
-    isActive: group?.isActive,
-    isPending: pendingSuggestions.has(normalizedUrl),
-    isDismissed: dismissedUrlGroups.has(normalizedUrl),
+    groupCount: autoSyncState.groups.size,
+    hasAnyPendingSuggestions,
+    hasAnyDismissedGroups,
   });
 
   if (!group || group.tabIds.size < 2) {
-    logger.debug('[AUTO-SYNC] Cannot show suggestion - group not found or too small', {
-      normalizedUrl,
-      groupExists: !!group,
-      groupSize: group?.tabIds.size,
-    });
+    logger.debug('[AUTO-SYNC] Cannot show suggestion - group not found or too small');
     return;
   }
 
   if (dismissedUrlGroups.has(normalizedUrl)) {
-    logger.debug('[AUTO-SYNC] Skipping suggestion - URL group dismissed by user', {
-      normalizedUrl,
-    });
+    logger.debug('[AUTO-SYNC] Skipping suggestion - URL group dismissed by user');
     return;
   }
 
   if (isDomainPermanentlyExcluded(normalizedUrl)) {
     logger.debug('[AUTO-SYNC] Skipping suggestion - domain is permanently excluded', {
-      normalizedUrl,
-      domain: extractDomainFromUrl(normalizedUrl),
+      isDomainExcluded: true,
     });
     return;
   }
 
   if (isDomainSnoozed(normalizedUrl)) {
     logger.debug('[AUTO-SYNC] Skipping suggestion - domain is snoozed', {
-      normalizedUrl,
-      domain: extractDomainFromUrl(normalizedUrl),
+      isDomainSnoozed: true,
     });
     return;
   }
 
   if (pendingSuggestions.has(normalizedUrl)) {
-    logger.debug('[AUTO-SYNC] Skipping suggestion - already pending', { normalizedUrl });
+    logger.debug('[AUTO-SYNC] Skipping suggestion - already pending');
     return;
   }
 
@@ -108,8 +98,7 @@ export async function showSyncSuggestion(normalizedUrl: string): Promise<void> {
     const hasSyncedTabWithSameUrl = await hasSyncedTabMatchingUrl(normalizedUrl);
     if (hasSyncedTabWithSameUrl) {
       logger.info('[AUTO-SYNC] Skipping suggestion - synced tabs share this normalized URL', {
-        normalizedUrl,
-        syncedTabs: syncState.linkedTabs,
+        syncedTabCount: syncState.linkedTabs.length,
       });
       return;
     }
@@ -144,8 +133,7 @@ export async function showSyncSuggestion(normalizedUrl: string): Promise<void> {
   // Only inject into tabs that don't respond to ping (no content script yet)
   // Also check if any tab is already syncing - if so, skip showing suggestion
   logger.info('[AUTO-SYNC] Checking content script status before showing suggestion', {
-    normalizedUrl,
-    targetTabs: uniqueTargetTabs,
+    targetTabCount: uniqueTargetTabs.length,
   });
 
   const tabsNeedingInjection: number[] = [];
@@ -184,7 +172,6 @@ export async function showSyncSuggestion(normalizedUrl: string): Promise<void> {
 
   // Log ping results summary
   logger.info('[AUTO-SYNC] Ping results summary', {
-    normalizedUrl,
     totalTabs: uniqueTargetTabs.length,
     tabsNeedingInjection: tabsNeedingInjection.length,
     hasActiveSyncTab,
@@ -192,9 +179,7 @@ export async function showSyncSuggestion(normalizedUrl: string): Promise<void> {
 
   // If any tab is already syncing, skip showing suggestion
   if (hasActiveSyncTab) {
-    logger.info('[AUTO-SYNC] Skipping suggestion - tabs are already syncing', {
-      normalizedUrl,
-    });
+    logger.info('[AUTO-SYNC] Skipping suggestion - tabs are already syncing');
     pendingSuggestions.delete(normalizedUrl);
     return;
   }
@@ -202,7 +187,7 @@ export async function showSyncSuggestion(normalizedUrl: string): Promise<void> {
   // Only inject into tabs without content scripts
   if (tabsNeedingInjection.length > 0) {
     logger.info('[AUTO-SYNC] Injecting content scripts into tabs without scripts', {
-      normalizedUrl,
+      tabCountNeedingInjection: tabsNeedingInjection.length,
       tabsNeedingInjection,
     });
 
@@ -228,10 +213,8 @@ export async function showSyncSuggestion(normalizedUrl: string): Promise<void> {
   }
 
   logger.info('[AUTO-SYNC] Showing sync suggestion toast on ALL tabs', {
-    normalizedUrl,
-    targetTabs: uniqueTargetTabs,
+    targetTabCount: uniqueTargetTabs.length,
     tabCount: tabIds.length,
-    tabTitles,
   });
 
   // Send toast to all tabs in parallel
@@ -293,7 +276,7 @@ export async function sendSuggestionToSingleTab(
   if (isDomainPermanentlyExcluded(normalizedUrl)) {
     logger.debug('[AUTO-SYNC] Skipping single-tab suggestion - domain is permanently excluded', {
       tabId,
-      normalizedUrl,
+      isDomainExcluded: true,
     });
     return;
   }
@@ -301,7 +284,7 @@ export async function sendSuggestionToSingleTab(
   if (isDomainSnoozed(normalizedUrl)) {
     logger.debug('[AUTO-SYNC] Skipping single-tab suggestion - domain is snoozed', {
       tabId,
-      normalizedUrl,
+      isDomainSnoozed: true,
     });
     return;
   }
@@ -354,7 +337,10 @@ export async function sendSuggestionToSingleTab(
       },
       { context: 'content-script', tabId },
     );
-    logger.info('[AUTO-SYNC] Sent suggestion to newly joined tab', { tabId, normalizedUrl });
+    logger.info('[AUTO-SYNC] Sent suggestion to newly joined tab', {
+      tabId,
+      groupTabCount: tabIds.length,
+    });
   } catch (error) {
     logger.warn('[AUTO-SYNC] Failed to send suggestion to new tab', { tabId, error });
   }
@@ -379,7 +365,7 @@ export async function showAddTabSuggestion(
   if (isDomainPermanentlyExcluded(normalizedUrl)) {
     logger.debug('[AUTO-SYNC] Skipping add-tab suggestion - domain is permanently excluded', {
       tabId,
-      normalizedUrl,
+      isDomainExcluded: true,
     });
     return;
   }
@@ -387,7 +373,7 @@ export async function showAddTabSuggestion(
   if (isDomainSnoozed(normalizedUrl)) {
     logger.debug('[AUTO-SYNC] Skipping add-tab suggestion - domain is snoozed', {
       tabId,
-      normalizedUrl,
+      isDomainSnoozed: true,
     });
     return;
   }
@@ -407,9 +393,8 @@ export async function showAddTabSuggestion(
 
   logger.info('[AUTO-SYNC] Showing add-tab suggestion toast on ALL tabs', {
     newTabId: tabId,
-    tabTitle,
     syncedTabs: syncState.linkedTabs,
-    allTargetTabs: uniqueTargetTabs,
+    targetTabCount: uniqueTargetTabs.length,
     hasManualOffsets,
   });
 

--- a/src/background/lib/sync-state.test.ts
+++ b/src/background/lib/sync-state.test.ts
@@ -102,7 +102,9 @@ describe('sync-state', () => {
 
       expect(mockedBrowser.storage.local.set).toHaveBeenCalledWith({ syncState });
       expect(loggerMock.debug).toHaveBeenCalledWith('Sync state persisted to storage', {
-        syncState,
+        isActive: true,
+        linkedTabCount: 2,
+        mode: undefined,
       });
     });
 
@@ -135,7 +137,9 @@ describe('sync-state', () => {
       expect(syncState.connectionStatuses).toEqual({ 7: 'connected' });
       expect(syncState.lastActiveSyncedTabId).toBe(7);
       expect(loggerMock.info).toHaveBeenCalledWith('Sync state restored from storage', {
-        syncState,
+        isActive: false,
+        linkedTabCount: 1,
+        mode: undefined,
       });
     });
 

--- a/src/background/lib/sync-state.ts
+++ b/src/background/lib/sync-state.ts
@@ -16,7 +16,11 @@ export const syncState: SyncState = {
 export async function persistSyncState(): Promise<void> {
   try {
     await browser.storage.local.set({ syncState });
-    logger.debug('Sync state persisted to storage', { syncState });
+    logger.debug('Sync state persisted to storage', {
+      isActive: syncState.isActive,
+      linkedTabCount: syncState.linkedTabs.length,
+      mode: syncState.mode,
+    });
   } catch (error) {
     logger.error('Failed to persist sync state', { error });
   }
@@ -27,7 +31,11 @@ export async function restoreSyncState(): Promise<void> {
     const result = await browser.storage.local.get('syncState');
     if (result.syncState) {
       Object.assign(syncState, result.syncState as SyncState);
-      logger.info('Sync state restored from storage', { syncState });
+      logger.info('Sync state restored from storage', {
+        isActive: syncState.isActive,
+        linkedTabCount: syncState.linkedTabs.length,
+        mode: syncState.mode,
+      });
 
       if (syncState.isActive && syncState.linkedTabs.length >= 2) {
         logger.info('Reconnecting previously synced tabs after service worker restart');

--- a/src/contentScripts/scroll-sync.ts
+++ b/src/contentScripts/scroll-sync.ts
@@ -314,7 +314,7 @@ const handleScroll = throttleAndDebounce(handleScrollCore, THROTTLE_DELAY);
  * Broadcast URL change to other tabs (P1)
  */
 async function broadcastUrlChange(url: string) {
-  logger.info('URL changed, broadcasting to other tabs', { url });
+  logger.info('URL changed, broadcasting to other tabs', { tabId: syncState.tabId });
 
   // Clear manual scroll offset when navigating to a new page (source tab)
   // Only clear if URL sync is enabled - old offset values won't be useful on a new page
@@ -565,7 +565,7 @@ async function requestReconnection(attemptNumber = 0): Promise<boolean> {
       connectionState.isReconnecting = false;
       return true;
     } else {
-      logger.warn('Reconnection attempt failed', { attemptNumber, response });
+      logger.warn('Reconnection attempt failed', { attemptNumber });
     }
   } catch (error) {
     logger.warn('Reconnection attempt error', { attemptNumber, error });
@@ -754,7 +754,10 @@ export function initScrollSync() {
   // Listen for stop sync message
   onMessage('scroll:stop', async ({ data }) => {
     const payload = data;
-    logger.info('Stopping scroll sync', { data, isAutoSync: payload.isAutoSync });
+    logger.info('Stopping scroll sync', {
+      tabId: syncState.tabId,
+      isAutoSync: payload.isAutoSync ?? false,
+    });
 
     // Auto-sync stop should only stop auto-sync (not interfere with manual sync)
     // But manual stop (from popup) should work regardless of sync type
@@ -814,7 +817,10 @@ export function initScrollSync() {
     // Update last successful sync time for connection health monitoring
     connectionState.lastSuccessfulSync = Date.now();
 
-    logger.debug('Receiving scroll sync', { data });
+    logger.debug('Receiving scroll sync', {
+      sourceTabId: payload.sourceTabId,
+      mode: payload.mode,
+    });
 
     // Calculate the synced ratio from source tab
     const sourceRatio = payload.scrollTop / (payload.scrollHeight - payload.clientHeight);
@@ -925,7 +931,7 @@ export function initScrollSync() {
   onMessage('scroll:ping', async ({ data }) => {
     const payload = data;
     logger.debug('Received ping from background', {
-      payload,
+      pingTabId: payload.tabId,
       isSyncActive: syncState.isActive,
       tabId: syncState.tabId,
     });
@@ -1039,7 +1045,6 @@ export function initScrollSync() {
   onMessage('sync-suggestion:show', async ({ data }) => {
     const payload = data;
     logger.info('Showing sync suggestion toast', {
-      normalizedUrl: payload.normalizedUrl,
       tabCount: payload.tabCount,
     });
     showSyncSuggestionToast(payload);
@@ -1051,7 +1056,7 @@ export function initScrollSync() {
     const payload = data;
     logger.info('Showing add tab suggestion toast', {
       tabId: payload.tabId,
-      tabTitle: payload.tabTitle,
+      hasMatchKind: payload.matchKind !== undefined,
     });
     showAddTabSuggestionToast(payload);
     return { success: true };

--- a/src/contentScripts/suggestion-toast.tsx
+++ b/src/contentScripts/suggestion-toast.tsx
@@ -554,7 +554,6 @@ function renderToast() {
 export async function showSyncSuggestionToast(suggestion: SyncSuggestionMessage) {
   // Debug logging to diagnose toast display issues
   logger.debug('[SuggestionToast] showSyncSuggestionToast called', {
-    normalizedUrl: suggestion.normalizedUrl,
     tabCount: suggestion.tabCount,
     hasContainer: !!toastContainer,
     containerInDOM: toastContainer ? document.body.contains(toastContainer) : false,

--- a/src/shared/components/ui/dropdown-menu.tsx
+++ b/src/shared/components/ui/dropdown-menu.tsx
@@ -20,7 +20,6 @@ function DropdownMenuContent({
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
         ref={ref}
-        sideOffset={sideOffset}
         className={cn(
           'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
           'data-[state=open]:animate-in data-[state=closed]:animate-out',
@@ -30,6 +29,7 @@ function DropdownMenuContent({
           'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           className,
         )}
+        sideOffset={sideOffset}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>


### PR DESCRIPTION
## Summary
- Adds a stacked follow-up PR on top of #385 (`codex/url-sync-mode-design`) so the URL Sync mode work can merge first without main-branch conflicts.
- Adds privacy-safe logging validation for raw URL/title/payload/syncState leaks and sanitizes existing logging metadata.
- Adds real Chromium extension E2E coverage for URL Sync modes and a required `extension-pr-checks` GitHub Actions gate.

## Validation
- `privacy:logging:test`
- `privacy:logging`
- `i18n:validate`
- `typecheck`
- `lint:check`
- `vitest run`
- Chromium production build
- Firefox production build
- preserved Chromium build `test:e2e:extension`

## Security notes
- The PR workflow uses `pull_request`, not `pull_request_target`.
- Workflow permissions are limited to `contents: read`.
- No secrets, repository admin tokens, or automatic ruleset/branch-protection changes are used.

Stacked on: #385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new PR check for extension-related changes, including validation, tests, builds, and smoke E2E coverage.
  * Added browser extension end-to-end coverage for URL Sync modes and popup state persistence.
  * Added privacy-logging validation to help catch sensitive log output.

* **Tests**
  * Expanded automated checks for extension workflows and added supporting test fixtures.

* **Chores**
  * Updated ignored build/test artifacts to keep generated reports out of source control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->