### PR TITLE
ci: skip extension PR checks for Renovate PRs

### DIFF
--- a/.github/workflows/extension-pr-checks.yml
+++ b/.github/workflows/extension-pr-checks.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   extension-pr-checks:
     name: extension-pr-checks
+    if: ${{ github.event.pull_request.user.login != 'renovate[bot]' }}
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.57.0-noble


### PR DESCRIPTION
## Summary
- Skip the Extension PR Checks job when the PR author is renovate[bot].
- Use the PR author instead of the triggering actor so reopened Renovate PRs stay skipped.

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/extension-pr-checks.yml'); puts 'ok'"