### PR TITLE
fix: sync follow changed tab query params

### DIFF
--- a/docs/superpowers/plans/2026-07-03-follow-changed-tab-query-sync.md
+++ b/docs/superpowers/plans/2026-07-03-follow-changed-tab-query-sync.md
@@ -167,7 +167,9 @@ function buildPathOrSubdomainLocaleSearch(source: URL, target: URL): string {
 
 - [ ] **Step 2: Use source identity search for targets without locale markers**
 
-In `src/shared/lib/translated-page-url-utils.ts`, replace the `if (!targetLocale)` branch inside `applyTranslatedPageLocaleSync()`:
+In `src/shared/lib/translated-page-url-utils.ts`, update the no-target-locale flow inside
+`applyTranslatedPageLocaleSync()` to handle query-sourced locales before the generic fallback.
+Replace the old branch:
 
 ```typescript
 if (!targetLocale) {
@@ -185,7 +187,22 @@ if (!targetLocale) {
 with:
 
 ```typescript
+if (sourceLocale?.source === 'query' && !targetLocale) {
+  return buildUrlFromParts(
+    source.protocol,
+    source.hostname,
+    source.port,
+    source.pathname,
+    buildSourceIdentitySearch(source),
+    target.hash,
+  );
+}
+
 if (!targetLocale) {
+  if (sourceLocale) {
+    return sourceUrl;
+  }
+
   return buildUrlFromParts(
     source.protocol,
     source.hostname,
@@ -196,6 +213,11 @@ if (!targetLocale) {
   );
 }
 ```
+
+The early query-source branch strips locale-valued query carriers such as `lang` and `hl` via
+`buildSourceIdentitySearch(source)`. The generic fallback still returns `sourceUrl` for path or
+subdomain source locales when the target has no locale marker, and otherwise rebuilds the URL with
+the source identity query and target hash.
 
 - [ ] **Step 3: Run the focused utility tests**
 

--- a/docs/superpowers/plans/2026-07-03-follow-changed-tab-query-sync.md
+++ b/docs/superpowers/plans/2026-07-03-follow-changed-tab-query-sync.md
@@ -1,0 +1,296 @@
+# Follow Changed Tab Query Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `follow-changed-tab` URL Sync copy source page-identifying query parameters while preserving target language carriers.
+
+**Architecture:** Keep the behavior change inside `src/shared/lib/translated-page-url-utils.ts`, where URL Sync target URLs are already resolved. Add focused Vitest coverage for the pure resolver and one content-script scenario so the actual `url:sync` receiver path cannot regress.
+
+**Tech Stack:** TypeScript, Vitest, webext-bridge message tests, webextension-polyfill mocks, pnpm.
+
+---
+
+## File Structure
+
+- Modify: `src/shared/lib/translated-page-url-utils.test.ts`
+  - Responsibility: prove `follow-changed-tab` applies source identity query and does not treat locale-valued query params as ordinary page identity.
+- Modify: `src/__tests__/scenarios.test.ts`
+  - Responsibility: prove the content-script `url:sync` handler navigates with source query parameters when URL Sync is enabled.
+- Modify: `src/shared/lib/translated-page-url-utils.ts`
+  - Responsibility: build the final URL for translated-page and URL Sync navigation.
+- No changes: `src/shared/types/messages.ts`, `shim.d.ts`, popup UI, background relay, locale JSON files, scroll timing, auto-sync grouping, landing, release, deploy, or store-stats workflows.
+
+## Task 1: Add Regression Tests For Follow-Changed Query Sync
+
+**Files:**
+
+- Modify: `src/shared/lib/translated-page-url-utils.test.ts`
+- Modify: `src/__tests__/scenarios.test.ts`
+
+- [ ] **Step 1: Add pure URL utility tests**
+
+In `src/shared/lib/translated-page-url-utils.test.ts`, inside the `describe('applyTranslatedPageLocaleSync')` block, add these tests after the existing test named `uses target carrier when source and target carriers differ` and before the test named `falls back to source URL when parsing fails`:
+
+```typescript
+it('uses source identity query when target has no locale marker', () => {
+  expect(
+    applyTranslatedPageLocaleSync(
+      'https://search.example.com/results?query=hello&page=2&utm_source=mail',
+      'https://search.example.com/',
+    ),
+  ).toBe('https://search.example.com/results?page=2&query=hello');
+});
+
+it('does not copy locale-valued query carriers as identity query without target locale', () => {
+  expect(
+    applyTranslatedPageLocaleSync(
+      'https://example.com/docs/search?lang=en&query=hello&hl=ko',
+      'https://example.com/docs',
+    ),
+  ).toBe('https://example.com/docs/search?query=hello');
+});
+```
+
+In the same file, inside the `describe('resolveUrlSyncTarget')` block, add this test after the test named `keeps existing behavior for follow-changed-tab mode`:
+
+```typescript
+it('syncs Naver-shaped source query parameters in follow-changed-tab mode', () => {
+  expect(
+    resolveUrlSyncTarget(
+      'https://search.naver.com/search.naver?where=nexearch&sm=top_hty&fbm=0&ie=utf8&query=hello&ackey=0eid74s6',
+      'https://www.naver.com/#home',
+      'follow-changed-tab',
+    ),
+  ).toEqual({
+    status: 'navigate',
+    url: 'https://search.naver.com/search.naver?ackey=0eid74s6&fbm=0&ie=utf8&query=hello&sm=top_hty&where=nexearch#home',
+  });
+});
+```
+
+- [ ] **Step 2: Add a content-script scenario test**
+
+In `src/__tests__/scenarios.test.ts`, inside the `describe('Scenario: URL sync behavior')` block, add this test after the test named `when URL sync is enabled, url:sync receiver navigates`:
+
+```typescript
+it('when follow-changed-tab is active, url:sync receiver keeps source query params', async () => {
+  await startContentSync(27);
+  await saveUrlSyncEnabled(true);
+  await saveUrlSyncMode('follow-changed-tab');
+  setWindowUrl('https://www.naver.com/#target');
+
+  await invokeContentMessage('url:sync', {
+    url: 'https://search.naver.com/search.naver?where=nexearch&sm=top_hty&fbm=0&ie=utf8&query=hello&ackey=0eid74s6',
+    sourceTabId: 99,
+  });
+
+  expect(window.location.href).toBe(
+    'https://search.naver.com/search.naver?ackey=0eid74s6&fbm=0&ie=utf8&query=hello&sm=top_hty&where=nexearch#target',
+  );
+});
+```
+
+- [ ] **Step 3: Run focused utility tests and verify the expected failure**
+
+Run:
+
+```bash
+pnpm vitest run src/shared/lib/translated-page-url-utils.test.ts
+```
+
+Expected before implementation: FAIL. The new no-locale-marker tests fail because the resolver still uses `target.search`.
+
+Expected failure shape:
+
+```text
+expected 'https://search.example.com/results' to be 'https://search.example.com/results?page=2&query=hello'
+```
+
+- [ ] **Step 4: Run the content-script scenario and verify the expected failure**
+
+Run:
+
+```bash
+pnpm vitest run src/__tests__/scenarios.test.ts -t "when follow-changed-tab is active"
+```
+
+Expected before implementation: FAIL. The scenario fails because `window.location.href` is missing the source query string.
+
+Expected failure shape:
+
+```text
+expected 'https://search.naver.com/search.naver#target' to be 'https://search.naver.com/search.naver?ackey=0eid74s6&fbm=0&ie=utf8&query=hello&sm=top_hty&where=nexearch#target'
+```
+
+The important failure is that the pre-fix URL has no source query string.
+
+- [ ] **Step 5: Commit the failing tests**
+
+Run:
+
+```bash
+git add src/shared/lib/translated-page-url-utils.test.ts src/__tests__/scenarios.test.ts
+git commit -m "test: cover follow changed tab query sync"
+```
+
+## Task 2: Implement Source Identity Query Sync
+
+**Files:**
+
+- Modify: `src/shared/lib/translated-page-url-utils.ts`
+- Test: `src/shared/lib/translated-page-url-utils.test.ts`
+- Test: `src/__tests__/scenarios.test.ts`
+
+- [ ] **Step 1: Add a source identity search helper**
+
+In `src/shared/lib/translated-page-url-utils.ts`, replace the current `buildPathOrSubdomainLocaleSearch()` helper:
+
+```typescript
+function buildPathOrSubdomainLocaleSearch(source: URL, target: URL): string {
+  const identityQuery = stringifyQueryParams(getIdentityQueryParams(source.searchParams));
+  return identityQuery ? `?${identityQuery}` : target.search;
+}
+```
+
+with:
+
+```typescript
+function buildSourceIdentitySearch(source: URL): string {
+  const identityQuery = stringifyQueryParams(getIdentityQueryParams(source.searchParams));
+  return identityQuery ? `?${identityQuery}` : '';
+}
+
+function buildPathOrSubdomainLocaleSearch(source: URL, target: URL): string {
+  return buildSourceIdentitySearch(source) || target.search;
+}
+```
+
+- [ ] **Step 2: Use source identity search for targets without locale markers**
+
+In `src/shared/lib/translated-page-url-utils.ts`, replace the `if (!targetLocale)` branch inside `applyTranslatedPageLocaleSync()`:
+
+```typescript
+if (!targetLocale) {
+  return buildUrlFromParts(
+    source.protocol,
+    source.hostname,
+    source.port,
+    source.pathname,
+    target.search,
+    target.hash,
+  );
+}
+```
+
+with:
+
+```typescript
+if (!targetLocale) {
+  return buildUrlFromParts(
+    source.protocol,
+    source.hostname,
+    source.port,
+    source.pathname,
+    buildSourceIdentitySearch(source),
+    target.hash,
+  );
+}
+```
+
+- [ ] **Step 3: Run the focused utility tests**
+
+Run:
+
+```bash
+pnpm vitest run src/shared/lib/translated-page-url-utils.test.ts
+```
+
+Expected: PASS. The new no-locale-marker tests pass, and existing path/query/subdomain locale preservation tests still pass.
+
+- [ ] **Step 4: Run the content-script scenario test**
+
+Run:
+
+```bash
+pnpm vitest run src/__tests__/scenarios.test.ts -t "when follow-changed-tab is active"
+```
+
+Expected: PASS. The receiver navigates to the source website/path with sorted source identity query parameters and the target hash.
+
+- [ ] **Step 5: Commit the implementation**
+
+Run:
+
+```bash
+git add src/shared/lib/translated-page-url-utils.ts
+git commit -m "fix: sync follow changed tab query params"
+```
+
+## Task 3: Verify Privacy, Types, And URL Sync Boundaries
+
+**Files:**
+
+- Inspect: `src/shared/lib/translated-page-url-utils.ts`
+- Inspect: `src/shared/lib/translated-page-url-utils.test.ts`
+- Inspect: `src/__tests__/scenarios.test.ts`
+- Inspect: `src/contentScripts/scroll-sync.ts`
+- Inspect: `src/background/handlers/scroll-sync-handlers.ts`
+
+- [ ] **Step 1: Run all relevant regression tests**
+
+Run:
+
+```bash
+pnpm vitest run src/shared/lib/translated-page-url-utils.test.ts src/__tests__/scenarios.test.ts
+```
+
+Expected: PASS. URL utility tests and content-script scenarios pass together.
+
+- [ ] **Step 2: Run the AGENTS.md privacy search**
+
+Run:
+
+```bash
+rg -n "logger|url|Url|URL|tab\\.url|window\\.location\\.href|payload|normalizedUrl|sourceUrl|targetUrl" src/shared/lib/translated-page-url-utils.ts src/shared/lib/translated-page-url-utils.test.ts src/__tests__/scenarios.test.ts src/contentScripts/scroll-sync.ts src/background/handlers/scroll-sync-handlers.ts
+```
+
+Expected: Matches are reviewed manually. Accept URL manipulation in resolver code and test fixtures. Reject any new `logger` call that includes source URLs, target URLs, resolved URLs, tab titles, document titles, whole `payload`, or page metadata.
+
+- [ ] **Step 3: Run the repository privacy validator**
+
+Run:
+
+```bash
+pnpm privacy:logging
+```
+
+Expected: PASS. No raw URL, tab title, page metadata, storage payload, or message payload logging violations are reported.
+
+- [ ] **Step 4: Run typecheck**
+
+Run:
+
+```bash
+pnpm typecheck
+```
+
+Expected: PASS. No public type or message payload shape changed.
+
+- [ ] **Step 5: Review final tracked diff**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -3
+```
+
+Expected: The branch contains the docs spec commit plus two implementation commits:
+
+```text
+fix: sync follow changed tab query params
+test: cover follow changed tab query sync
+docs: add follow changed tab query sync design
+```
+
+The pre-existing untracked `.playwright-mcp/` directory may still appear. Leave it untracked unless the user explicitly asks to handle it.

--- a/docs/superpowers/specs/2026-06-27-url-sync-mode-design.md
+++ b/docs/superpowers/specs/2026-06-27-url-sync-mode-design.md
@@ -185,6 +185,12 @@ This mode follows the source website and page, preserves the target language car
 source page-identifying query, and preserves the target hash according to the existing
 locale-preserving behavior.
 
+When the target URL has no language carrier, the mode still follows the source website and page with
+the source page-identifying query. If the source language carrier is query-based, language-only
+query values such as `lang` or `hl` are stripped before rebuilding the navigation URL. If the source
+language carrier is path- or subdomain-based and the target has no language carrier, the source URL
+can be used as-is because the language remains part of the source path or host.
+
 ### Keep Each Tab's Website
 
 Use the target tab's website boundary and apply the source page movement inside it.

--- a/docs/superpowers/specs/2026-06-28-extension-pr-checks-design.md
+++ b/docs/superpowers/specs/2026-06-28-extension-pr-checks-design.md
@@ -208,6 +208,7 @@ enough URL variety to exercise the product behavior:
 - different website boundary, same matching page
 - path movement
 - query-language carrier
+- source page-identifying query parameters in `Follow changed tab`
 - hash preservation when applicable
 
 Different websites can be represented with local origins, such as different loopback hosts or ports,
@@ -220,6 +221,7 @@ The required smoke suite should cover these cases:
 1. `Follow changed tab`
    - Another tab follows the changed tab's website.
    - The target tab's language is preserved when possible.
+   - Source page-identifying query parameters are applied when the target has no language carrier.
 2. `Keep each tab's website`
    - Another tab stays on its own website.
    - The changed page movement is applied within that website.

--- a/docs/superpowers/specs/2026-07-03-follow-changed-tab-query-sync-design.md
+++ b/docs/superpowers/specs/2026-07-03-follow-changed-tab-query-sync-design.md
@@ -59,12 +59,20 @@ Keep the fix in the pure URL utility layer:
 
 - `resolveUrlSyncTarget(sourceUrl, targetUrl, 'follow-changed-tab')` continues to delegate to
   `applyTranslatedPageLocaleSync(sourceUrl, targetUrl)`.
-- `applyTranslatedPageLocaleSync()` should use the existing `getIdentityQueryParams()` path when it
-  rebuilds a source-website URL for a target without a locale marker.
+- `applyTranslatedPageLocaleSync()` should use `buildSourceIdentitySearch(source)` when it rebuilds
+  a source-website URL for a target without a locale marker.
+- When the source locale came from query parameters and the target has no locale marker,
+  `applyTranslatedPageLocaleSync()` should take an early `sourceLocale?.source === 'query' &&
+  !targetLocale` branch. That branch rebuilds the URL with `buildSourceIdentitySearch(source)`,
+  stripping locale-valued query carriers such as `lang` and `hl` while preserving source identity
+  query parameters.
+- The generic `!targetLocale` fallback should keep returning `sourceUrl` for path/subdomain source
+  locales. If neither side has a locale marker, it should rebuild from the source protocol, host,
+  path, source identity query, and target hash.
 - The existing path/query/subdomain locale branches should stay on the same helper path they already
   use, because those branches already apply source identity query while preserving target language.
 
-The changed no-target-locale branch should build:
+The changed no-target-locale rebuild path should build:
 
 ```text
 source protocol + source host + source path + source identity query + target hash

--- a/docs/superpowers/specs/2026-07-03-follow-changed-tab-query-sync-design.md
+++ b/docs/superpowers/specs/2026-07-03-follow-changed-tab-query-sync-design.md
@@ -1,0 +1,138 @@
+# Follow Changed Tab Query Sync Design
+
+## Context
+
+URL Sync has two modes:
+
+- `follow-changed-tab`: other tabs move to the website and page changed by the source tab.
+- `keep-each-tabs-website`: other tabs keep their current website and open the matching page.
+
+The existing mode design says `follow-changed-tab` should use the source page-identifying query
+while preserving each target tab's language carrier. The implementation does this when the target
+has a path, query, or subdomain locale marker, but it keeps `target.search` when the target has no
+locale marker.
+
+This causes search/result pages to lose query parameters. Example:
+
+```text
+A before: https://www.naver.com/
+B before: https://www.naver.com/
+
+A after:
+https://search.naver.com/search.naver?where=nexearch&sm=top_hty&fbm=0&ie=utf8&query=hello&ackey=0eid74s6
+
+B actual after:
+https://search.naver.com/search.naver
+```
+
+The expected behavior is that B follows the same search page including the source page-identifying
+query. Site-generated query values may change after navigation; the extension should not add
+site-specific Naver rules.
+
+## Goal
+
+Make `follow-changed-tab` synchronize page-identifying query parameters the same way
+`keep-each-tabs-website` does, without changing language preservation behavior.
+
+Success criteria:
+
+- Source identity query parameters are applied when `follow-changed-tab` receives a source URL with
+  query parameters and the target URL has no locale marker.
+- Target language carriers are still preserved for path locale, query locale, and subdomain locale
+  targets.
+- Locale-valued language query parameters such as `lang=en`, `locale=ko`, or `hl=ja` remain language
+  carriers, not ordinary page identity query parameters.
+- Tracking query parameters already treated as noise stay excluded from synced identity query.
+- No raw URL or tab title logging is added.
+
+## Non-Goals
+
+- Do not add Naver-specific query rewriting.
+- Do not copy target query parameters that are not language carriers.
+- Do not change URL Sync message payloads or `ProtocolMap`.
+- Do not change auto-sync grouping, tab discovery, popup UI, or scroll timing behavior.
+- Do not change how URL Sync preserves the target hash.
+
+## Design
+
+Keep the fix in the pure URL utility layer:
+
+- `resolveUrlSyncTarget(sourceUrl, targetUrl, 'follow-changed-tab')` continues to delegate to
+  `applyTranslatedPageLocaleSync(sourceUrl, targetUrl)`.
+- `applyTranslatedPageLocaleSync()` should use the existing `getIdentityQueryParams()` path when it
+  rebuilds a source-website URL for a target without a locale marker.
+- The existing path/query/subdomain locale branches should stay on the same helper path they already
+  use, because those branches already apply source identity query while preserving target language.
+
+The changed no-target-locale branch should build:
+
+```text
+source protocol + source host + source path + source identity query + target hash
+```
+
+instead of:
+
+```text
+source protocol + source host + source path + target query + target hash
+```
+
+This keeps the behavior mode-general and avoids any search-engine-specific assumptions.
+
+## Data Flow
+
+1. A source tab changes URL and sends `url:sync` with the changed tab URL.
+2. Background relays the message unchanged.
+3. Each target content script checks URL Sync enabled state and repairs the stored mode if needed.
+4. The target content script resolves the navigation URL with its current URL and the stored mode.
+5. For `follow-changed-tab`, the resolver follows the source website and page, preserves target
+   language carriers, applies source identity query, and preserves the target hash.
+6. If the resolved URL differs from the current URL, manual offset is cleared and the content script
+   navigates.
+
+## Error Handling
+
+Do not add new error states. Existing behavior stays:
+
+- If either URL cannot be parsed in `follow-changed-tab`, return the source URL as the legacy
+  fallback.
+- If the resolved URL equals the current URL, skip navigation and do not clear manual offset.
+- If storage repair fails before resolution, skip navigation and surface the existing URL Sync
+  notice.
+
+## Privacy
+
+This change manipulates raw URLs in memory because navigation requires them, but it must not log
+source URLs, target URLs, resolved URLs, tab titles, document titles, payload objects, or page
+metadata. Existing logging should remain limited to tab IDs, mode, reason, counts, and booleans.
+
+Before finishing implementation, run the repository privacy scan required by `AGENTS.md` for URL
+Sync changes and review any logger-adjacent matches manually.
+
+## Testing
+
+Add pure utility regression tests in `src/shared/lib/translated-page-url-utils.test.ts`:
+
+- `follow-changed-tab` applies source identity query when the target has no locale marker.
+- A Naver-shaped source URL resolves to the same host/path with the source query, while preserving the
+  target hash if present.
+- `follow-changed-tab` still preserves target query locale and combines source identity query with
+  the target locale query.
+- `follow-changed-tab` still preserves target path locale and subdomain locale.
+
+Add a content script scenario test only if pure utility coverage does not protect the actual
+`url:sync` receiver path clearly enough. The existing scenario tests already cover enabled URL Sync
+navigation and locale preservation, so a single no-target-locale query scenario is sufficient if
+added.
+
+Verification commands:
+
+```bash
+pnpm vitest run src/shared/lib/translated-page-url-utils.test.ts
+pnpm vitest run src/__tests__/scenarios.test.ts
+pnpm privacy:logging
+pnpm typecheck
+```
+
+If time is tight, the minimum verification is the translated-page utility test plus the privacy
+logging scan, because the behavior change is isolated to the pure URL resolver and touches raw URL
+handling.

--- a/docs/superpowers/specs/2026-07-03-follow-changed-tab-query-sync-design.md
+++ b/docs/superpowers/specs/2026-07-03-follow-changed-tab-query-sync-design.md
@@ -63,7 +63,7 @@ Keep the fix in the pure URL utility layer:
   a source-website URL for a target without a locale marker.
 - When the source locale came from query parameters and the target has no locale marker,
   `applyTranslatedPageLocaleSync()` should take an early `sourceLocale?.source === 'query' &&
-  !targetLocale` branch. That branch rebuilds the URL with `buildSourceIdentitySearch(source)`,
+!targetLocale` branch. That branch rebuilds the URL with `buildSourceIdentitySearch(source)`,
   stripping locale-valued query carriers such as `lang` and `hl` while preserving source identity
   query parameters.
 - The generic `!targetLocale` fallback should keep returning `sourceUrl` for path/subdomain source

--- a/src/__tests__/scenarios.test.ts
+++ b/src/__tests__/scenarios.test.ts
@@ -390,6 +390,22 @@ describe('Scenario: URL sync toggle behavior', () => {
     expect(window.location.href).toBe(targetUrl);
   });
 
+  it('when follow-changed-tab is active, url:sync receiver keeps source query params', async () => {
+    await startContentSync(27);
+    await saveUrlSyncEnabled(true);
+    await saveUrlSyncMode('follow-changed-tab');
+    setWindowUrl('https://www.naver.com/#target');
+
+    await invokeContentMessage('url:sync', {
+      url: 'https://search.naver.com/search.naver?where=nexearch&sm=top_hty&fbm=0&ie=utf8&query=hello&ackey=0eid74s6',
+      sourceTabId: 99,
+    });
+
+    expect(window.location.href).toBe(
+      'https://search.naver.com/search.naver?ackey=0eid74s6&fbm=0&ie=utf8&query=hello&sm=top_hty&where=nexearch#target',
+    );
+  });
+
   it('preserves target query locale when relaying URL sync', async () => {
     await startContentSync(23);
     await saveUrlSyncEnabled(true);

--- a/src/shared/lib/locale-utils.test.ts
+++ b/src/shared/lib/locale-utils.test.ts
@@ -97,10 +97,10 @@ describe('applyLocalePreservingSync', () => {
     expect(result).toBe('https://example.com/en-US/docs/install');
   });
 
-  it('should use source pathname when neither has locale', () => {
+  it('should use source pathname and identity query when neither has locale', () => {
     const result = applyLocalePreservingSync(
-      'https://example.com/docs/install',
-      'https://example.com/docs/next?foo=bar',
+      'https://example.com/docs/install?foo=bar',
+      'https://example.com/docs/next?stale=true',
     );
     expect(result).toBe('https://example.com/docs/install?foo=bar');
   });

--- a/src/shared/lib/locale-utils.ts
+++ b/src/shared/lib/locale-utils.ts
@@ -109,8 +109,8 @@ export function removeLocaleFromPath(pathname: string, locale: string): string {
  * 3. 대상만 로케일 포함: 소스 경로를 대상의 로케일로 변환
  * 4. 둘 다 없음: 소스 경로 사용
  *
- * 대상에 로케일이 있거나 둘 다 로케일이 없으면 대상의 해시를 보존함
- * 대상 쿼리는 경로/서브도메인 로케일에서는 보존되고, 쿼리 로케일에서는 소스 식별 쿼리와 대상 로케일 쿼리를 사용함
+ * 대상 해시는 보존함
+ * 쿼리는 소스 식별 쿼리를 사용하되, 대상이 쿼리 로케일을 쓰는 경우 대상 로케일 쿼리를 보존함
  * 소스만 로케일을 포함하고 대상에 로케일이 없으면 소스 URL을 그대로 사용함
  *
  * @param sourceUrl 변경된 소스 탭의 URL
@@ -136,8 +136,8 @@ export function removeLocaleFromPath(pathname: string, locale: string): string {
  * @example
  * // 로케일 없음: 기본 동작
  * applyLocalePreservingSync(
- *   "https://example.com/docs/install",
- *   "https://example.com/docs/next?foo=bar"
+ *   "https://example.com/docs/install?foo=bar",
+ *   "https://example.com/docs/next?stale=true"
  * )
  * // → "https://example.com/docs/install?foo=bar"
  */

--- a/src/shared/lib/translated-page-url-utils.test.ts
+++ b/src/shared/lib/translated-page-url-utils.test.ts
@@ -277,6 +277,24 @@ describe('applyTranslatedPageLocaleSync', () => {
     ).toBe('https://example.com/tr/docs/install?page=setup#target');
   });
 
+  it('uses source identity query when target has no locale marker', () => {
+    expect(
+      applyTranslatedPageLocaleSync(
+        'https://search.example.com/results?query=hello&page=2&utm_source=mail',
+        'https://search.example.com/',
+      ),
+    ).toBe('https://search.example.com/results?page=2&query=hello');
+  });
+
+  it('does not copy locale-valued query carriers as identity query without target locale', () => {
+    expect(
+      applyTranslatedPageLocaleSync(
+        'https://example.com/docs/search?lang=en&query=hello&hl=ko',
+        'https://example.com/docs',
+      ),
+    ).toBe('https://example.com/docs/search?query=hello');
+  });
+
   it('falls back to source URL when parsing fails', () => {
     expect(applyTranslatedPageLocaleSync('not-a-url', 'https://example.com/tr/docs')).toBe(
       'not-a-url',
@@ -295,6 +313,19 @@ describe('resolveUrlSyncTarget', () => {
     ).toEqual({
       status: 'navigate',
       url: 'https://example.com/ko/about?tab=pricing#intro',
+    });
+  });
+
+  it('syncs Naver-shaped source query parameters in follow-changed-tab mode', () => {
+    expect(
+      resolveUrlSyncTarget(
+        'https://search.naver.com/search.naver?where=nexearch&sm=top_hty&fbm=0&ie=utf8&query=hello&ackey=0eid74s6',
+        'https://www.naver.com/#home',
+        'follow-changed-tab',
+      ),
+    ).toEqual({
+      status: 'navigate',
+      url: 'https://search.naver.com/search.naver?ackey=0eid74s6&fbm=0&ie=utf8&query=hello&sm=top_hty&where=nexearch#home',
     });
   });
 

--- a/src/shared/lib/translated-page-url-utils.ts
+++ b/src/shared/lib/translated-page-url-utils.ts
@@ -507,6 +507,9 @@ export function applyTranslatedPageLocaleSync(sourceUrl: string, targetUrl: stri
   const sourceLocale = getLocaleDescriptor(source);
   const targetLocale = getLocaleDescriptor(target);
 
+  // Query-sourced locales are page-language markers, so strip them while keeping
+  // source identity query. Path/subdomain locales can keep the source URL as-is
+  // when the target has no locale marker to preserve their URL-carried language.
   if (sourceLocale?.source === 'query' && !targetLocale) {
     return buildUrlFromParts(
       source.protocol,

--- a/src/shared/lib/translated-page-url-utils.ts
+++ b/src/shared/lib/translated-page-url-utils.ts
@@ -304,8 +304,12 @@ function buildTargetQuerySearch(source: URL, targetLocale: LocaleDescriptor): st
 }
 
 function buildPathOrSubdomainLocaleSearch(source: URL, target: URL): string {
+  return buildSourceIdentitySearch(source) || target.search;
+}
+
+function buildSourceIdentitySearch(source: URL): string {
   const identityQuery = stringifyQueryParams(getIdentityQueryParams(source.searchParams));
-  return identityQuery ? `?${identityQuery}` : target.search;
+  return identityQuery ? `?${identityQuery}` : '';
 }
 
 function buildPathLocaleUrl(
@@ -503,17 +507,28 @@ export function applyTranslatedPageLocaleSync(sourceUrl: string, targetUrl: stri
   const sourceLocale = getLocaleDescriptor(source);
   const targetLocale = getLocaleDescriptor(target);
 
-  if (sourceLocale && !targetLocale) {
-    return sourceUrl;
-  }
-
-  if (!targetLocale) {
+  if (sourceLocale?.source === 'query' && !targetLocale) {
     return buildUrlFromParts(
       source.protocol,
       source.hostname,
       source.port,
       source.pathname,
-      target.search,
+      buildSourceIdentitySearch(source),
+      target.hash,
+    );
+  }
+
+  if (!targetLocale) {
+    if (sourceLocale) {
+      return sourceUrl;
+    }
+
+    return buildUrlFromParts(
+      source.protocol,
+      source.hostname,
+      source.port,
+      source.pathname,
+      buildSourceIdentitySearch(source),
       target.hash,
     );
   }


### PR DESCRIPTION
## Summary
- Sync source identity query params in follow-changed-tab mode when the target has no locale marker
- Keep language query carriers from being copied as page identity params
- Align legacy locale sync wrapper expectations with the shared URL sync resolver

## Test Plan
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/esno scripts/validate-privacy-logging.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved URL sync behavior so the active tab can carry over the source tab’s key query parameters while keeping the destination page’s language setting.
  * Added support for preserving the destination hash during synced navigation.

* **Bug Fixes**
  * Fixed cases where query parameters were lost or replaced during locale-aware URL syncing.
  * Improved handling for URLs without an obvious locale marker, making sync results more consistent across tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->