### PR TITLE
docs: clarify auto-sync exclusion matching

### DIFF
--- a/src/shared/lib/auto-sync-url-utils.ts
+++ b/src/shared/lib/auto-sync-url-utils.ts
@@ -53,8 +53,8 @@ export function normalizeUrlForAutoSync(url: string): string | null {
 /**
  * Check whether a URL matches any of the given exclusion patterns.
  *
- * Patterns use simplified glob syntax where `*` matches any characters
- * and `/` is escaped for regex matching.
+ * Patterns use substring wildcard semantics: `*` matches any character sequence,
+ * while non-wildcard segments are matched literally and in order.
  *
  * @param url - URL string to test
  * @param patterns - Array of glob-like exclusion patterns


### PR DESCRIPTION
## Summary

- update `isUrlExcluded()` JSDoc to describe the linear substring wildcard matcher introduced in #399
- remove the stale reference to regex escaping

## Rationale

CodeRabbit's actionable security comment was correctly implemented in #399, but the adjacent documentation still described the previous regex behavior. This PR only aligns the documentation with the merged implementation.

## Validation

- pre-commit `lint-and-format-ts`
- pre-commit `typecheck`
- no additional tests run (documentation-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified URL exclusion pattern behavior, including substring wildcards and ordered literal matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->