### PR TITLE
fix: restore Edge release submissions

### DIFF
--- a/.github/workflows/publish-edge-release.yml
+++ b/.github/workflows/publish-edge-release.yml
@@ -1,0 +1,54 @@
+name: Publish Edge Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Released semantic version
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: edge-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  publish-edge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Download released Chromium package
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          if [[ ! "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release version." >&2
+            exit 1
+          fi
+          gh release download "v${RELEASE_VERSION}" \
+            --pattern synchronize-tab-scrolling-chrome.zip
+
+      - name: Publish Edge Add-ons
+        env:
+          EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
+          EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: node scripts/publish-edge.mjs "${RELEASE_VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,9 +93,6 @@ jobs:
           GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
           AMO_API_KEY: ${{ secrets.AMO_API_KEY }}
           AMO_API_SECRET: ${{ secrets.AMO_API_SECRET }}
-          EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
-          EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
-          EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
         run: |
           package_version="$(node -p "require('./package.json').version")"
           if [[ "${package_version}" != "${RELEASE_VERSION}" ]]; then
@@ -103,3 +100,12 @@ jobs:
             exit 1
           fi
           pnpm exec semantic-release
+
+      - name: Publish Edge Add-ons
+        continue-on-error: true
+        env:
+          RELEASE_VERSION: ${{ needs.check-release.outputs.version }}
+          EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
+          EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
+        run: node scripts/publish-edge.mjs "${RELEASE_VERSION}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,8 +127,10 @@ pnpm start:firefox      # Launch in Firefox
 
 - **Extension release**: manually dispatch `Prepare Release PR`, review/merge the generated
   version + CHANGELOG PR, then semantic-release publishes to Chrome Web Store + Firefox AMO +
-  Edge Add-ons. Ordinary extension merges run only the version gate and do not publish. Dual build
-  (Chrome + Firefox). Edge API key expires — manual renewal
+  GitHub Releases. A separate best-effort step publishes Edge Add-ons, and the manual Publish Edge
+  Release workflow retries an existing release asset. Ordinary extension merges run only the
+  version gate and do not publish. Dual build (Chrome + Firefox). Edge API key expires — manual
+  renewal
 - **Extension PR checks**: required `extension-pr-checks` status. Extension-impacting PRs run
   privacy logging validation, i18n validation, typecheck, lint check, unit tests, Chrome/Firefox
   builds, and the URL Sync mode plus safe-navigation smoke E2E.

--- a/docs/guides/store-deployment.md
+++ b/docs/guides/store-deployment.md
@@ -32,22 +32,25 @@ release PR required checks 통과 및 병합
               ├─ vX.Y.Z tag 생성
               ├─ semantic-release-chrome → Chrome Web Store 업로드
               ├─ semantic-release-amo → Firefox AMO 업로드
-              ├─ github → GitHub Release 생성 + zip 에셋 첨부
-              └─ exec → scripts/publish-edge.mjs (Chrome zip으로 Edge 업로드)
+              └─ github → GitHub Release 생성 + zip 에셋 첨부
+
+Edge Add-ons best-effort step
+    └─ scripts/publish-edge.mjs → Chrome zip을 Edge에 업로드·제출
 ```
 
 ---
 
 ## 관련 파일
 
-| 파일                                       | 역할                                                         |
-| ------------------------------------------ | ------------------------------------------------------------ |
-| `.github/workflows/prepare-release-pr.yml` | 다음 버전과 CHANGELOG를 담은 release PR 생성                 |
-| `.github/workflows/release.yml`            | 승인된 package version의 빌드, 패키징, semantic-release 실행 |
-| `scripts/prepare-release-pr.ts`            | semantic-release dry-run 결과를 package/CHANGELOG에 반영     |
-| `release.config.js`                        | semantic-release publish 플러그인 구성                       |
-| `scripts/publish-edge.mjs`                 | Edge Add-ons API 호출 스크립트 (soft-fail 지원)              |
-| `src/manifest.ts`                          | 동적 manifest.json 생성 — 브라우저별 분기                    |
+| 파일                                         | 역할                                                     |
+| -------------------------------------------- | -------------------------------------------------------- |
+| `.github/workflows/prepare-release-pr.yml`   | 다음 버전과 CHANGELOG를 담은 release PR 생성             |
+| `.github/workflows/release.yml`              | 승인된 package version의 빌드, 패키징, 스토어 배포       |
+| `.github/workflows/publish-edge-release.yml` | 기존 GitHub Release asset의 Edge 수동 재제출             |
+| `scripts/prepare-release-pr.ts`              | semantic-release dry-run 결과를 package/CHANGELOG에 반영 |
+| `release.config.js`                          | semantic-release publish 플러그인 구성                   |
+| `scripts/publish-edge.mjs`                   | Edge Add-ons API 호출 스크립트                           |
+| `src/manifest.ts`                            | 동적 manifest.json 생성 — 브라우저별 분기                |
 
 ---
 
@@ -87,9 +90,14 @@ pnpm build-firefox     # Firefox staging → build/firefox/
 
 ### Microsoft Edge Add-ons
 
-- **방식**: `@semantic-release/exec` → `scripts/publish-edge.mjs`
-- **동작**: Chrome zip을 Edge Add-ons API v1.1로 업로드 (Edge는 Chromium 기반이므로 Chrome 빌드 재사용)
-- **Soft-fail**: 자격증명이 없으면 경고만 출력하고 exit 0 (Chrome/Firefox/GitHub Release는 정상 진행)
+- **방식**: semantic-release 완료 후 별도 `Publish Edge Add-ons` step에서
+  `scripts/publish-edge.mjs` 실행
+- **동작**: Chrome zip을 Edge Add-ons API v1.1로 업로드하고 certification notes 없이
+  제출 (Edge는 Chromium 기반이므로 Chrome 빌드 재사용)
+- **Soft-fail**: Edge step은 `continue-on-error`이므로 실패해도 이미 완료된
+  Chrome/Firefox/GitHub Release를 실패로 바꾸지 않음
+- **수동 재시도**: `Publish Edge Release` workflow에 이미 릴리스된 버전을 입력하면 해당
+  GitHub Release의 Chrome zip을 내려받아 Edge에 다시 제출
 - **자격증명**: API Key + Client ID + Product ID
 
 ---
@@ -240,8 +248,12 @@ release App은 `main`을 직접 push하지 않으므로 ruleset bypass actor가 
 ### Edge Add-ons 업로드 실패
 
 - `401 Unauthorized`: API Key 만료 → Partner Center에서 갱신
+- publish 단계의 `400 Bad Request`: `Publish Edge Release` workflow에 릴리스 버전을 입력해
+  GitHub Release의 동일 Chrome zip을 certification notes 없이 재제출
 - `409 Conflict`: 이전 제출이 아직 처리 중 → 잠시 후 재시도
 - Edge 배포 실패는 릴리스 전체를 차단하지 않음 (soft-fail)
+- tag나 GitHub Release를 삭제하지 않음. Chrome/Firefox에 이미 게시된 동일 버전을 다시
+  semantic-release로 배포하지 않음
 
 ### 워크플로우 디버깅
 

--- a/release.config.js
+++ b/release.config.js
@@ -55,7 +55,6 @@ export default {
       {
         verifyReleaseCmd:
           'pnpm exec esno scripts/prepare-release-pr.ts --verify ${nextRelease.version}',
-        publishCmd: 'node scripts/publish-edge.mjs ${nextRelease.version}',
       },
     ],
   ],

--- a/scripts/publish-edge.mjs
+++ b/scripts/publish-edge.mjs
@@ -18,7 +18,7 @@ const client = new EdgeAddonsAPI({
 try {
   await client.submit({
     filePath: 'synchronize-tab-scrolling-chrome.zip',
-    notes: `Release v${version}`,
+    notes: '',
   });
   console.log(`Edge Add-ons: v${version} submitted successfully.`);
 } catch (error) {

--- a/scripts/publish-edge.test.mjs
+++ b/scripts/publish-edge.test.mjs
@@ -1,0 +1,44 @@
+import path from 'node:path';
+
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+const submit = vi.hoisted(() => vi.fn());
+
+vi.mock('@plasmohq/edge-addons-api', () => ({
+  EdgeAddonsAPI: class {
+    submit = submit;
+  },
+}));
+
+const originalArgv = [...process.argv];
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.stubEnv('EDGE_PRODUCT_ID', 'product-id');
+  vi.stubEnv('EDGE_CLIENT_ID', 'client-id');
+  vi.stubEnv('EDGE_API_KEY', 'api-key');
+  process.argv.splice(
+    0,
+    process.argv.length,
+    process.execPath,
+    path.resolve(import.meta.dirname, 'publish-edge.mjs'),
+    '2.15.0',
+  );
+  submit.mockReset().mockResolvedValue(undefined);
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  process.argv.splice(0, process.argv.length, ...originalArgv);
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+it('submits the Edge package without certification notes', async () => {
+  await import('./publish-edge.mjs');
+
+  expect(submit).toHaveBeenCalledWith({
+    filePath: 'synchronize-tab-scrolling-chrome.zip',
+    notes: '',
+  });
+});

--- a/scripts/release-workflow.test.ts
+++ b/scripts/release-workflow.test.ts
@@ -9,6 +9,10 @@ async function readRepositoryFile(relativePath: string): Promise<string> {
   return readFile(path.join(repositoryRoot, relativePath), 'utf8');
 }
 
+async function readOptionalRepositoryFile(relativePath: string): Promise<string> {
+  return readRepositoryFile(relativePath).catch(() => '');
+}
+
 describe('release workflow boundaries', () => {
   it('publishes only a package version that does not already have a tag', async () => {
     const workflow = await readRepositoryFile('.github/workflows/release.yml');
@@ -44,5 +48,29 @@ describe('release workflow boundaries', () => {
     expect(releaseConfig).toContain('scripts/prepare-release-pr.ts --verify');
     expect(releaseConfig).not.toContain("'@semantic-release/git'");
     expect(releaseConfig).not.toContain("'@semantic-release/changelog'");
+  });
+
+  it('keeps Edge publishing outside the semantic-release transaction', async () => {
+    const [releaseConfig, workflow] = await Promise.all([
+      readRepositoryFile('release.config.js'),
+      readRepositoryFile('.github/workflows/release.yml'),
+    ]);
+    const releaseIndex = workflow.indexOf('pnpm exec semantic-release');
+    const edgeIndex = workflow.indexOf('name: Publish Edge Add-ons');
+
+    expect(releaseConfig).not.toContain('publishCmd');
+    expect(workflow).toContain('continue-on-error: true');
+    expect(releaseIndex).toBeGreaterThan(-1);
+    expect(edgeIndex).toBeGreaterThan(releaseIndex);
+  });
+
+  it('can retry Edge publishing from an existing GitHub release asset', async () => {
+    const workflow = await readOptionalRepositoryFile('.github/workflows/publish-edge-release.yml');
+
+    expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).toContain('description: Released semantic version');
+    expect(workflow).toContain('gh release download');
+    expect(workflow).toContain('synchronize-tab-scrolling-chrome.zip');
+    expect(workflow).toContain('node scripts/publish-edge.mjs');
   });
 });


### PR DESCRIPTION
## Summary

- submit Edge packages without certification notes, avoiding the publish request that has returned 400 since v2.14.2
- move Edge outside the semantic-release transaction so Chrome, Firefox, and GitHub releases remain successful if Edge fails
- add a manual `Publish Edge Release` workflow that reuses the exact Chromium asset from an existing GitHub Release
- document the recovery path and tag-preservation rule

## Root cause evidence

- v2.15.0 run 31872765198 successfully created the tag/GitHub Release and published Chrome + Firefox before Edge returned 400
- v2.14.2 run 30751724576 failed at the same Edge publish boundary
- the Edge client reached `publish()` only after upload validation succeeded; the only extra publish input was certification notes
- the existing guide promised soft-fail, while the exec plugin propagated Edge failure to semantic-release

## Validation

- RED: 3 focused failures for notes, transaction isolation, and manual retry workflow
- GREEN: `vitest` 33/33 across affected tests and privacy logging rules
- ESLint, Prettier, TypeScript, YAML parse, diff check
- i18n validation and privacy logging validation (270 files)
- no local E2E; required PR CI owns the existing targeted smoke coverage

## Follow-up after merge

Run `Publish Edge Release` with version `2.15.0`, then verify the Edge submission result. Do not delete or recreate the existing v2.15.0 tag.